### PR TITLE
New methods in gopherpolicy

### DIFF
--- a/gopherpolicy/cache.go
+++ b/gopherpolicy/cache.go
@@ -43,6 +43,10 @@ func (c inMemoryCacher) StoreTokenPayload(token string, payload []byte) {
 	c.Add(cacheKeyFor(token), payload)
 }
 
+func (c inMemoryCacher) RemoveTokenPayload(token string) {
+	c.Remove(cacheKeyFor(token))
+}
+
 func (c inMemoryCacher) LoadTokenPayload(token string) []byte {
 	val, ok := c.Get(cacheKeyFor(token))
 	if !ok {

--- a/gopherpolicy/pkg.go
+++ b/gopherpolicy/pkg.go
@@ -54,6 +54,9 @@ type Cacher interface {
 	//from the cache. If there nothing cached for these credentials, or if the
 	//retrieval fails, nil shall be returned.
 	LoadTokenPayload(credentials string) []byte
+	//RemoveTokenPayload removes the payload for the given credentials
+	//from the cache.
+	RemoveTokenPayload(credentials string)
 }
 
 //TokenValidator combines an Identity v3 client to validate tokens (AuthN), and

--- a/gopherpolicy/token.go
+++ b/gopherpolicy/token.go
@@ -116,6 +116,18 @@ func (t *Token) ProjectScopeName() string {
 	return t.Context.Auth["project_name"]
 }
 
+//ProjectScopeDomainUUID returns the UUID of this token's project scope domain, or ""
+//if the token is invalid or not scoped to a project.
+func (t *Token) ProjectScopeDomainUUID() string {
+	return t.Context.Auth["project_domain_id"]
+}
+
+//ProjectScopeDomainName returns the name of this token's project scope domain, or ""
+//if the token is invalid or not scoped to a project.
+func (t *Token) ProjectScopeDomainName() string {
+	return t.Context.Auth["project_domain_name"]
+}
+
 //DomainScopeUUID returns the UUID of this token's domain scope, or "" if the token is
 //invalid or not scoped to a domain.
 func (t *Token) DomainScopeUUID() string {


### PR DESCRIPTION
RemoveTokenPayload is required in case, when we cache token using ec2 crednetials cache key.
E.g. we check ec2 crednetials. It cached even if they don't return required role. When user adds missing role, application still uses the cached token, till the token is expired.