### PR TITLE
Remove amqp dependency from audittools/trail.go

### DIFF
--- a/audittools/doc.go
+++ b/audittools/doc.go
@@ -29,6 +29,9 @@ One usage of the aforementioned implementation can be:
 	package yourPackageName
 
 	import (
+		"net/url"
+		...
+
 		"github.com/sapcc/go-bits/audittools"
 		...
 	)
@@ -60,20 +63,19 @@ One usage of the aforementioned implementation can be:
 		}
 
 		rabbitmqQueueName := "down-the-rabbit-hole"
-		rabbitmqURI := amqp.URI{
-			Scheme:   "amqp",
-			Host:     "localhost",
-			Port:     5672,
-			Username: "guest",
-			Password: "guest",
-			Vhost:    "/",
+		rabbitmqURI := url.URL{
+			Scheme: "amqp",
+			Host:   "localhost",
+			Port:   5672,
+			User:   url.UserPassword("guest", "guest"),
+			Path:   "/",
 		}
 
 		go audittools.AuditTrail{
 			EventSink:           s,
 			OnSuccessfulPublish: onSuccessFunc,
 			OnFailedPublish:     onFailFunc,
-		}.Commit(rabbitmqQueueName, rabbitmqURI)
+		}.Commit(rabbitmqURI.String(), rabbitmqQueueName)
 	}
 
 	func someFunction() {

--- a/audittools/trail.go
+++ b/audittools/trail.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/hermes/pkg/cadf"
-	"github.com/streadway/amqp"
 )
 
 // AuditTrail holds an event sink for receiving audit events and closure functions
@@ -39,15 +38,14 @@ type AuditTrail struct {
 // a specific RabbitMQ Connection using the specified amqp URI and queue name.
 // The OnSuccessfulPublish and OnFailedPublish closures are executed as per
 // their respective case.
-func (t AuditTrail) Commit(rabbitmqQueueName string, rabbitmqURI amqp.URI) {
-	uriStr := rabbitmqURI.String()
-	rc, err := NewRabbitConnection(uriStr, rabbitmqQueueName)
+func (t AuditTrail) Commit(rabbitmqURI, rabbitmqQueueName string) {
+	rc, err := NewRabbitConnection(rabbitmqURI, rabbitmqQueueName)
 	if err != nil {
 		logg.Error(err.Error())
 	}
 
 	sendEvent := func(e *cadf.Event) bool {
-		rc = refreshConnectionIfClosedOrOld(rc, uriStr, rabbitmqQueueName)
+		rc = refreshConnectionIfClosedOrOld(rc, rabbitmqURI, rabbitmqQueueName)
 		err := rc.PublishEvent(e)
 		if err != nil {
 			t.OnFailedPublish()


### PR DESCRIPTION
amqp dependency was introduced in #13. We build and parse the URL directly in the `pkg/config` file in our go project, which is shared between other projects. Adding amqp causes useless dependencies to all other projects, which use our initial `pkg/config`. Since it is just a URL and you convert it back to string I think it'd be wise to revert this back and keep the initial func args order: url, queue.