### PR TITLE
extend SQL utility libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ reusability. Feel free to add to this.
 
 * [assert](./assert) contains various assertions for unit tests.
 * [audittools](./audittools) contains helper functions for establishing a connection to a RabbitMQ server (with sane defaults) and publishing messages to it.
-* [easypg](./postlite) is a database library for applications that use PostgreSQL. It integrates [golang-migrate/migrate](https://github.com/golang-migrate/migrate) for data definition and imports the libpq-based SQL driver.
+* [easypg](./easypg) is a database library for applications that use PostgreSQL. It integrates [golang-migrate/migrate](https://github.com/golang-migrate/migrate) for data definition and imports the libpq-based SQL driver.
 * [gopherpolicy](./gopherpolicy) integrates [Gophercloud](https://github.com/gophercloud/gophercloud) with [goslo.policy](https://github.com/databus23/goslo.policy), for OpenStack services that need to validate client tokens and check permissions.
 * [httpapi](./httpapi) contains opinionated base machinery for assembling and exposing an API consisting of HTTP endpoints.
 * [httpext](./httpext) adds some convenience functions to [net/http](https://golang.org/pkg/http/).
@@ -17,6 +17,7 @@ reusability. Feel free to add to this.
 * [respondwith](./respondwith) contains some helper functions for generating responses in HTTP handlers.
 * [secrets](./secrets) provides convenience functions for working with auth credentials.
 * [sre](./sre) contains a HTTP middleware that emits SRE-related Prometheus metrics.
+* [sqlext](./sqlext) contains helper functions for SQL queries that are not specific to PostgreSQL.
 
 ## Tools
 

--- a/easypg/easypg.go
+++ b/easypg/easypg.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sapcc/go-bits/easypg/migrate/database"
 	"github.com/sapcc/go-bits/easypg/migrate/database/postgres"
 	bindata "github.com/sapcc/go-bits/easypg/migrate/source/go_bindata"
+	"github.com/sapcc/go-bits/sqlext"
 
 	//enable postgres driver for database/sql
 	_ "github.com/lib/pq"
@@ -170,16 +171,11 @@ func runMigration(m *migrate.Migrate, err error) error {
 	return err
 }
 
-var sqlCommentRx = regexp.MustCompile(`--.*?(\n|$)`)
-
 func stripWhitespace(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 	for filename, sql := range in {
-		sqlWithoutComments := sqlCommentRx.ReplaceAllString(sql, "")
-		out[filename] = strings.Replace(
-			strings.Join(strings.Fields(sqlWithoutComments), " "),
-			"; ", ";\n", -1,
-		)
+		sqlSimplified := sqlext.SimplifyWhitespace(sql)
+		out[filename] = strings.Replace(sqlSimplified, "; ", ";\n", -1)
 	}
 	return out
 }

--- a/sqlext/doc.go
+++ b/sqlext/doc.go
@@ -1,0 +1,20 @@
+/******************************************************************************
+*
+*  Copyright 2022 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+//Package sqlext contains helper functions for SQL queries that are not specific to PostgreSQL.
+package sqlext

--- a/sqlext/interfaces.go
+++ b/sqlext/interfaces.go
@@ -1,0 +1,48 @@
+/******************************************************************************
+*
+*  Copyright 2022 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package sqlext
+
+import "database/sql"
+
+//Executor contains the common methods that both SQL connections (*sql.DB) and
+//transactions (*sql.Tx) implement. This is useful for functions that don't
+//care whether they execute within a transaction or not.
+//
+//For compatibility with applications using gorp (the ORM library), this
+//interface only contains methods that are also implemented by *gorp.DbMap and
+//*gorp.Transaction. This interface is therefore a restricted version of type
+//gorp.SqlExecutor, from which it inherits its name.
+type Executor interface {
+	Exec(query string, args ...any) (sql.Result, error)
+	Prepare(query string) (*sql.Stmt, error)
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+//Rollbacker contains the Rollback() method from *sql.Tx. This interface is
+//also satisfied by other types with transaction-like behavior like
+//*gorp.Transaction.
+type Rollbacker interface {
+	Rollback() error
+}
+
+//verify interface coverage
+var _ Executor = &sql.DB{}
+var _ Executor = &sql.Tx{}
+var _ Rollbacker = &sql.Tx{}

--- a/sqlext/utils.go
+++ b/sqlext/utils.go
@@ -1,0 +1,127 @@
+/******************************************************************************
+*
+*  Copyright 2017-2020 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package sqlext
+
+import (
+	"database/sql"
+	"regexp"
+
+	"github.com/sapcc/go-bits/logg"
+)
+
+//ForeachRow calls db.Query() with the given query and args, then executes the
+//given action one for every row in the result set. It then cleans up the
+//result set, and collects any errors that occur during all of this.
+//
+//Inside the action, you only have to call rows.Scan() and use the values
+//obtained from it. For example:
+//
+//    err := sqlext.ForeachRow(tx,
+//      `SELECT value FROM metadata WHERE key = $1`, []any{"mykey"},
+//      func(rows *sql.Rows) error {
+//        var value string
+//        err := rows.Scan(&value)
+//        if err != nil {
+//          return err
+//        }
+//        logg.Info("value fetched: %q", value)
+//        return nil
+//      },
+//    )
+func ForeachRow(db Executor, query string, args []any, action func(*sql.Rows) error) error {
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		err = action(rows)
+		if err != nil {
+			rows.Close()
+			return err
+		}
+	}
+	err = rows.Err()
+	if err != nil {
+		rows.Close()
+		return err
+	}
+	return rows.Close()
+}
+
+//RollbackUnlessCommitted calls Rollback() on a transaction if it hasn't been
+//committed or rolled back yet. Use this with the defer keyword to make sure
+//that a transaction is automatically rolled back when a function fails.
+func RollbackUnlessCommitted(tx Rollbacker) {
+	err := tx.Rollback()
+	switch err {
+	case nil:
+		//rolled back successfully
+		logg.Info("implicit rollback done")
+		return
+	case sql.ErrTxDone:
+		//already committed or rolled back - nothing to do
+		return
+	default:
+		logg.Error("implicit rollback failed: %s", err.Error())
+	}
+}
+
+var sqlWhitespaceOrCommentRx = regexp.MustCompile(`\s+(?m:--.*$)?`)
+
+//SimplifyWhitespace takes an SQL query string that's hardcoded in the program
+//and simplifies all the whitespaces, esp. ensuring that there are no comments
+//and newlines. This makes the database log nicer when queries are logged there
+//(e.g. for running too long), while still allowing nice multi-line formatting
+//and inline comments in the source code.
+func SimplifyWhitespace(query string) string {
+	return sqlWhitespaceOrCommentRx.ReplaceAllString(query, " ")
+}
+
+//WithPreparedStatement calls db.Prepare() and passes the resulting prepared
+//statement into the given action. It then cleans up the prepared statements,
+//and it collects any errors that occur during all of this.
+//
+//Inside the action, you only have to call stmt.Exec() as often as you need.
+//For example:
+//
+//    var someData map[string]string
+//    err := sqlext.WithPreparedStatement(tx,
+//      `INSERT INTO datatable (key, value) VALUES ($1, $2)`,
+//      func(stmt *sql.Stmt) error {
+//        for k, v := range someData {
+//          err := stmt.Exec(k, v)
+//          if err != nil {
+//            return err
+//          }
+//        }
+//        return nil
+//      },
+//    )
+func WithPreparedStatement(db Executor, query string, action func(*sql.Stmt) error) error {
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		return err
+	}
+	err = action(stmt)
+	if err != nil {
+		stmt.Close()
+		return err
+	}
+	return stmt.Close()
+}


### PR DESCRIPTION
In this PR:

## Package "sqlext"

This new package contains a bunch of helper functions for SQL statements that are independent of Postgres and thus don't really fit into "easypg".

Most of these functions originate from Limes, except for WithPreparedStatement that started in Keppel. All have been copied around quite a bit ever since. The implementations have not been changed from their imported versions, except for type name adjustments and `s/interface{}/any/`.

Where the original names included "SQL", this part has been dropped from the names since the package is already named "sqlext". For example, we have SimplifyWhitespaceInSQL which is now "sqlext.SimplifyWhitespace".

## Package "easypg"

Some new test helper functions are added to aid with reproducible test setup. These, too, originate from Limes and have been copied around ever since. These functions have been slightly rewritten for readability.

## More?

I was going to do more in this round, but some of the repetitive setup that we do for DBs (e.g. sqlstats and SetMaxOpenConns) is just one-liners already, so we're not gaining anything by moving them into here.

We do have some repetitiveness in our DB setup phases because all services use very similar logic for building the PostgresURI from env variables, but I will address that in a separate PR that will focus on the env var topic specifically.