### PR TITLE
add httpext.WrapTransport(), standardize common logging choices

### DIFF
--- a/gopherpolicy/pkg.go
+++ b/gopherpolicy/pkg.go
@@ -34,6 +34,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"gopkg.in/yaml.v2"
+
+	"github.com/sapcc/go-bits/logg"
 )
 
 // Validator is the interface provided by TokenValidator. Application code
@@ -95,9 +97,13 @@ func (v *TokenValidator) CheckToken(r *http.Request) *Token {
 		return &Token{Err: errors.New("X-Auth-Token header missing")}
 	}
 
-	return v.CheckCredentials(tokenStr, func() TokenResult {
+	token := v.CheckCredentials(tokenStr, func() TokenResult {
 		return tokens.Get(v.IdentityV3, tokenStr)
 	})
+	token.Context.Logger = logg.Debug
+	logg.Debug("token has auth = %v", token.Context.Auth)
+	logg.Debug("token has roles = %v", token.Context.Roles)
+	return token
 }
 
 // CheckCredentials is a more generic version of CheckToken that can also be

--- a/httpext/server.go
+++ b/httpext/server.go
@@ -60,6 +60,7 @@ func ContextWithSIGINT(ctx context.Context, delay time.Duration) context.Context
 // ListenAndServeContext is a wrapper around http.ListenAndServe() that additionally
 // shuts down the HTTP server gracefully when the context expires, or if an error occurs.
 func ListenAndServeContext(ctx context.Context, addr string, handler http.Handler) error {
+	logg.Info("Listening on %s...", addr)
 	server := &http.Server{
 		Addr:              addr,
 		Handler:           handler,

--- a/httpext/transport.go
+++ b/httpext/transport.go
@@ -1,0 +1,123 @@
+/*******************************************************************************
+*
+* Copyright 2022 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package httpext
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+// WrappedTransport is a wrapper that adds various global behaviors to an
+// `http.RoundTripper` such as `http.DefaultTransport`.
+type WrappedTransport struct {
+	// Lock for updates to this struct's other member fields.
+	mutex sync.Mutex
+	// A reference to the original RoundTripper.
+	original http.RoundTripper
+	// This is what we swap in for the original RoundTripper.
+	outer *outerRoundTripper
+}
+
+// WrapTransport replaces the given `http.RoundTripper` with a wrapped version
+// that can be modified using the returned WrappedTransport instance. This
+// usually targets `http.DefaultTransport` like this:
+//
+//     transport := httpext.WrapTransport(&http.DefaultTransport)
+//     transport.SetOverrideUserAgent("example", "1.0")
+func WrapTransport(transport *http.RoundTripper) *WrappedTransport {
+	orig := *transport
+	w := &WrappedTransport{
+		original: orig,
+		outer:    &outerRoundTripper{inner: orig},
+	}
+	*transport = w.outer
+	return w
+}
+
+// Attach adds a custom modifier to the DefaultTransport. The provided function
+// will be used to wrap the existing RoundTripper instance.
+func (w *WrappedTransport) Attach(wrap func(http.RoundTripper) http.RoundTripper) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	w.outer.inner = wrap(w.outer.inner)
+}
+
+// SetInsecureSkipVerify sets the InsecureSkipVerify flag on the inner
+// Transport's tls.Config. This flag should only be set for testing, esp. to
+// enable capturing of requests made by this application through a tracing
+// proxy like mitmproxy.
+func (w *WrappedTransport) SetInsecureSkipVerify(insecure bool) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	//only change the http.Transport if we have to (this is important because the
+	//presence of a custom TLSClientConfig may disable some useful behaviors like
+	//HTTP/2-by-default, so we only want to instantiate it if actually necessary)
+	orig, ok := w.original.(*http.Transport)
+	if !ok {
+		panic(fmt.Sprintf("SetInsecureSkipVerify: requires the wrapped RoundTripper to be a *http.DefaultTransport, but is actually a %t", w.original))
+	}
+	oldInsecure := orig.TLSClientConfig != nil && orig.TLSClientConfig.InsecureSkipVerify
+	if oldInsecure == insecure {
+		return
+	}
+
+	if orig.TLSClientConfig == nil {
+		orig.TLSClientConfig = &tls.Config{}
+	}
+	orig.TLSClientConfig.InsecureSkipVerify = insecure
+}
+
+// SetOverrideUserAgent sets a User-Agent header that will be injected into all
+// HTTP requests that are made with the http.DefaultTransport. The User-Agent
+// string is constructed as "appName/appVersion" from the two provided
+// arguments. The arguments usually come from go-api-declarations/bininfo, for example:
+//
+//     httpext.ModifyDefaultTransport().SetOverrideUserAgent(bininfo.Component(), bininfo.Version())
+func (w *WrappedTransport) SetOverrideUserAgent(appName, appVersion string) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if appVersion == "" {
+		w.outer.overrideUserAgent = appName
+	} else {
+		w.outer.overrideUserAgent = fmt.Sprintf("%s/%s", appName, appVersion)
+	}
+}
+
+// outerRoundTripper is what we actually put into `http.DefaultTransport`. Then
+// we can change the inner RoundTripper instance whenever we want without
+// having to touch `http.DefaultTransport` again, which is helpful in case a
+// different library has wrapped `http.DefaultTransport` again after us (e.g.
+// to install a test double).
+type outerRoundTripper struct {
+	inner             http.RoundTripper
+	overrideUserAgent string
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (o *outerRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if o.overrideUserAgent != "" {
+		r.Header.Set("User-Agent", o.overrideUserAgent)
+	}
+	return o.inner.RoundTrip(r)
+}

--- a/httpext/transport.go
+++ b/httpext/transport.go
@@ -41,9 +41,9 @@ type WrappedTransport struct {
 // that can be modified using the returned WrappedTransport instance. This
 // usually targets `http.DefaultTransport` like this:
 //
-//     transport := httpext.WrapTransport(&http.DefaultTransport)
-//     transport.SetOverrideUserAgent("example", "1.0")
-func WrapTransport(transport *http.RoundTripper) *WrappedTransport {
+//	transport := httpext.WrapTransport(&http.DefaultTransport)
+//	transport.SetOverrideUserAgent("example", "1.0")
+func WrapTransport(transport *http.RoundTripper) *WrappedTransport { //nolint:gocritic // The pointer to an interface type is intentional.
 	orig := *transport
 	w := &WrappedTransport{
 		original: orig,
@@ -82,7 +82,7 @@ func (w *WrappedTransport) SetInsecureSkipVerify(insecure bool) {
 	}
 
 	if orig.TLSClientConfig == nil {
-		orig.TLSClientConfig = &tls.Config{}
+		orig.TLSClientConfig = &tls.Config{} //nolint:gosec // only used in HTTP client, where stdlib auto-chooses strong TLS versions
 	}
 	orig.TLSClientConfig.InsecureSkipVerify = insecure
 }
@@ -92,7 +92,7 @@ func (w *WrappedTransport) SetInsecureSkipVerify(insecure bool) {
 // string is constructed as "appName/appVersion" from the two provided
 // arguments. The arguments usually come from go-api-declarations/bininfo, for example:
 //
-//     httpext.ModifyDefaultTransport().SetOverrideUserAgent(bininfo.Component(), bininfo.Version())
+//	httpext.ModifyDefaultTransport().SetOverrideUserAgent(bininfo.Component(), bininfo.Version())
 func (w *WrappedTransport) SetOverrideUserAgent(appName, appVersion string) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()

--- a/httpext/transport_test.go
+++ b/httpext/transport_test.go
@@ -1,0 +1,142 @@
+/*******************************************************************************
+*
+* Copyright 2022 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package httpext
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/sapcc/go-bits/assert"
+)
+
+func TestSetInsecureSkipVerify(t *testing.T) {
+	orig := &http.Transport{}
+	rt := http.RoundTripper(orig)
+	wrap := WrapTransport(&rt)
+
+	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, (*tls.Config)(nil))
+
+	wrap.SetInsecureSkipVerify(false)
+	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, (*tls.Config)(nil)) //check that false -> false is a true no-op
+
+	wrap.SetInsecureSkipVerify(true)
+	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, &tls.Config{InsecureSkipVerify: true})
+
+	wrap.SetInsecureSkipVerify(false)
+	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, &tls.Config{InsecureSkipVerify: false})
+}
+
+func TestOverridesAndWraps(t *testing.T) {
+	rt := http.RoundTripper(dummyRoundTripper{})
+
+	//baseline
+	hdr := makeDummyRequest(t, rt)
+	assert.DeepEqual(t, "response headers", hdr, http.Header{
+		"Host":   {"Dummy RoundTripper"},
+		"Origin": {"Dummy Request"},
+	})
+
+	//just wrapping the RoundTripper without configuring anything does not change the result
+	wrap := WrapTransport(&rt)
+	hdr = makeDummyRequest(t, rt)
+	assert.DeepEqual(t, "response headers", hdr, http.Header{
+		"Host":   {"Dummy RoundTripper"},
+		"Origin": {"Dummy Request"},
+	})
+
+	//now we add our User-Agent
+	wrap.SetOverrideUserAgent("foo", "1.0")
+	hdr = makeDummyRequest(t, rt)
+	assert.DeepEqual(t, "response headers", hdr, http.Header{
+		"Host":       {"Dummy RoundTripper"},
+		"Origin":     {"Dummy Request"},
+		"User-Agent": {"foo/1.0"},
+	})
+
+	//and we attach an additional middleware
+	wrap.Attach(addHeader("Foo", "Bar"))
+	hdr = makeDummyRequest(t, rt)
+	assert.DeepEqual(t, "response headers", hdr, http.Header{
+		"Foo":        {"Bar"},
+		"Host":       {"Dummy RoundTripper"},
+		"Origin":     {"Dummy Request"},
+		"User-Agent": {"foo/1.0"},
+	})
+}
+
+// A simple http.RoundTripper that just copies request headers into the response headers.
+type dummyRoundTripper struct{}
+
+func (dummyRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	hdr := make(http.Header, len(r.Header)+1)
+	for k, v := range r.Header {
+		hdr[k] = v
+	}
+	hdr.Set("Host", "Dummy RoundTripper")
+
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     hdr,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+		Request:    r,
+	}, nil
+}
+
+func makeDummyRequest(t *testing.T, rt http.RoundTripper) http.Header {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/", http.NoBody)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	req.Header.Set("Origin", "Dummy Request")
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer resp.Body.Close()
+	return resp.Header
+}
+
+// A http.RoundTripper middleware that we can use to test Attach().
+type headerAdder struct {
+	Key   string
+	Value string
+	Inner http.RoundTripper
+}
+
+func addHeader(key, value string) func(http.RoundTripper) http.RoundTripper {
+	return func(inner http.RoundTripper) http.RoundTripper {
+		return headerAdder{key, value, inner}
+	}
+}
+
+func (h headerAdder) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set(h.Key, h.Value)
+	return h.Inner.RoundTrip(r)
+}

--- a/httpext/transport_test.go
+++ b/httpext/transport_test.go
@@ -40,10 +40,10 @@ func TestSetInsecureSkipVerify(t *testing.T) {
 	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, (*tls.Config)(nil)) //check that false -> false is a true no-op
 
 	wrap.SetInsecureSkipVerify(true)
-	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, &tls.Config{InsecureSkipVerify: true})
+	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec // test fixture
 
 	wrap.SetInsecureSkipVerify(false)
-	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, &tls.Config{InsecureSkipVerify: false})
+	assert.DeepEqual(t, "TLSCLientConfig", orig.TLSClientConfig, &tls.Config{InsecureSkipVerify: false}) //nolint:gosec // test fixture
 }
 
 func TestOverridesAndWraps(t *testing.T) {
@@ -96,7 +96,7 @@ func (dummyRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	return &http.Response{
 		Status:     "200 OK",
-		StatusCode: 200,
+		StatusCode: http.StatusOK,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,


### PR DESCRIPTION
The first commit standardizes some common logging choices that we are currently copy-pasting between applications. Merging this will initially cause double-logging, which is not destructive, just a bit weird, and I will take care of removing the respective log lines from the application code once the PR is merged.

The bigger addition is `httpext.WrapTransport()`, which provides a standardized interface for the manipulation of `http.DefaultTransport`. This replaces other pieces of code that I keep copy-pasting. For example, <https://github.com/sapcc/limes/blob/master/pkg/util/http.go#L38-L44> can be rewritten as:

```go
wrap := httpext.WrapTransport(&http.DefaultTransport)
wrap.SetInsecureSkipVerify(osext.GetenvBool("LIMES_INSECURE"))
wrap.Attach(func (rt http.RoundTripper) http.RoundTripper { return loggingRoundTripper{rt} })
```