### PR TITLE
add package "pluggable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ reusability. Feel free to add to this.
 * [logg](./logg) adds some convenience functions to [log](https://golang.org/pkg/log/).
 * [must](./must) contains convenience functions for quickly exiting on fatal errors without the need for excessive `if err != nil`.
 * [osext](./osext) contains extensions to the standard library package "os", mostly relating to parsing of environment variables.
+* [pluggable](./pluggable) is a tiny plugin factory library, for constructing different objects implementing a common interface based on a configurable type selector.
 * [respondwith](./respondwith) contains some helper functions for generating responses in HTTP handlers.
 * [secrets](./secrets) provides convenience functions for working with auth credentials.
 * [sre](./sre) contains a HTTP middleware that emits SRE-related Prometheus metrics.

--- a/pluggable/pluggable.go
+++ b/pluggable/pluggable.go
@@ -1,0 +1,98 @@
+/******************************************************************************
+*
+*  Copyright 2022 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+// Package pluggable is a tiny plugin factory library. A factory object can be
+// set up that contains constructors for multiple different plugin types
+// implementing a common interface. Then plugin objects can be instantiated by
+// their plugin type identifier:
+//
+//	// The application must define a common interface for plugins that inherits
+//	// from the `pluggable.Plugin` interface.
+//	type MyPlugin interface {
+//		pluggable.Plugin
+//		ReadTheThing() (string, error)
+//		WriteTheThing(string) error
+//	}
+//	var MyRegistry pluggable.Registry[MyPlugin]
+//
+//	// Plugins the implement the application's plugin interface can register
+//	// themselves with the factory.
+//	func init() {
+//		MyRegistry.Add(func() MyPlugin { return MyImplementation{} })
+//	}
+//
+//	// Plugin instances can be created by referring to the plugin type ID:
+//	myInstance := MyRegistry.Instantiate("foobar")
+//	if myInstance == nil {
+//		panic("no foobar plugin!")
+//	}
+package pluggable
+
+import "fmt"
+
+// Plugin is the base interface for plugins that type Registry can instantiate.
+type Plugin interface {
+	// PluginTypeID must always return a constant string that is always the same
+	// for all instances of one type. Registry uses this ID to identify the
+	// plugin type that one particular constructor constructs.
+	PluginTypeID() string
+}
+
+// Registry is a container holding factories for multiple different plugin
+// types implementing a common interface. Refer to the package-level
+// documentation for details.
+type Registry[T Plugin] struct {
+	factories map[string]func() T
+}
+
+// Add adds a new plugin type to this Registry. The factory function will be
+// called once immediately to determine the PluginTypeID of the constructed
+// type, then stored for when this plugin type is called for during
+// Instantiate().
+func (r *Registry[T]) Add(factory func() T) {
+	if factory == nil {
+		panic("cannot register plugin with factory = nil")
+	}
+
+	pluginTypeID := factory().PluginTypeID()
+	if pluginTypeID == "" {
+		panic(`cannot register plugin with pluginTypeID = ""`)
+	}
+	if _, exists := r.factories[pluginTypeID]; exists {
+		panic(fmt.Sprintf("cannot register multiple plugins with pluginTypeID = %q", pluginTypeID))
+	}
+
+	if r.factories == nil {
+		r.factories = make(map[string]func() T)
+	}
+	r.factories[pluginTypeID] = factory
+}
+
+// Instantiate returns a new instance of the given plugin type.
+//
+// If the requested plugin type is not known, T's zero value will be returned.
+// Since T is usually an application-specific interface type, this means that
+// nil will be returned.
+func (r *Registry[T]) Instantiate(pluginTypeID string) T {
+	factory, exists := r.factories[pluginTypeID]
+	if exists {
+		return factory()
+	}
+	var zero T
+	return zero
+}

--- a/pluggable/pluggable_test.go
+++ b/pluggable/pluggable_test.go
@@ -1,0 +1,70 @@
+/******************************************************************************
+*
+*  Copyright 2022 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package pluggable
+
+import "testing"
+
+type testPlugin interface {
+	Plugin
+	ExampleData() int
+}
+
+type fooPlugin struct{}
+
+func (p fooPlugin) PluginTypeID() string { return "foo" }
+func (p fooPlugin) ExampleData() int     { return 42 }
+
+type barPlugin struct{}
+
+func (p barPlugin) PluginTypeID() string { return "bar" }
+func (p barPlugin) ExampleData() int     { return 23 }
+
+func TestRegistry(t *testing.T) {
+	var r Registry[testPlugin]
+	r.Add(func() testPlugin { return fooPlugin{} })
+	r.Add(func() testPlugin { return barPlugin{} })
+
+	testcases := []struct {
+		PluginTypeID string
+		ExampleData  int
+	}{
+		{"foo", 42},
+		{"bar", 23},
+	}
+
+	//check that known plugins are constructed correctly
+	for _, tc := range testcases {
+		instance := r.Instantiate(tc.PluginTypeID)
+		if instance == nil {
+			t.Errorf("expected to be able to construct a %q plugin, but got instance = nil", tc.PluginTypeID)
+		}
+		if instance.PluginTypeID() != tc.PluginTypeID {
+			t.Errorf("expected PluginTypeID = %q, but got %q", tc.PluginTypeID, instance.PluginTypeID())
+		}
+		if instance.ExampleData() != tc.ExampleData {
+			t.Errorf("expected ExampleData = %d, but got %d", tc.ExampleData, instance.ExampleData())
+		}
+	}
+
+	//check that unknown plugin type ID yields a nil
+	instance := r.Instantiate("something-else")
+	if instance != nil {
+		t.Errorf("expected a nil instance, but got %#v", instance)
+	}
+}


### PR DESCRIPTION
In all our big services, we have some sort of interface boundary that separates the core business logic from concrete implementations connecting to specific outside services:

* castellum: AssetManager
* limes: DiscoveryPlugin, QuotaPlugin, CapacityPlugin
* keppel: AuthDriver, StorageDriver, FederationDriver, InboundCacheDriver, RateLimitDriver
* tenso: ValidationHandler, TranslationHandler, DeliveryHandler

Each of these plugin interfaces uses the same ca. 20 LOC for registering and instantiating plugin types. If it were only for the code duplication, I would not even be doing this PR. But the sheer amount of tiny differences between these plugin interfaces is getting on my nerves more and more. This PR adds a type-safe base implementation of a plugin registry to go-bits that I want to move all of these plugin interfaces to.

I was going to say that this implementation is most similar to the one found in this or that service, but as it turns out, it's not completely identical to any of them. The big difference is that, for most plugin interfaces, the factory functions contain specific arguments besides the plugin type identifier. For example, Keppel's storage drivers take a reference to the main configuration object and the auth driver at construction time:

https://github.com/sapcc/keppel/blob/160978d0dac5f89d30ff5c8e838b33b3333d2f0f/internal/keppel/storage_driver.go#L120

This is difficult to express in generic code, so I'm not doing it at all. Instead, I will be moving all plugin interfaces to have an Init() method where configuration and references are taken in directly after construction. Limes and Tenso already have Init functions in their interfaces, so there is prior art for this. Since plugins are only constructed in a small number of places (usually in one place during configuration parsing in production code, and in one other place in test helpers for test code), so the risk of Init not being called is very small.
