### PR TITLE
jobloop: panic if required functions are not provided

### DIFF
--- a/jobloop/cron.go
+++ b/jobloop/cron.go
@@ -45,6 +45,10 @@ type CronJob struct {
 // metric. At runtime, `nil` can be given to use the default registry. In
 // tests, a test-local prometheus.Registry instance should be used instead.
 func (j *CronJob) Setup(registerer prometheus.Registerer) Job {
+	if j.Task == nil {
+		panic("Task must be set!")
+	}
+
 	j.Metadata.setup(registerer)
 	// NOTE: We wrap `j` into a private type instead of implementing the
 	// Job interface directly on `j` to enforce that callers run Setup().

--- a/jobloop/producer_consumer.go
+++ b/jobloop/producer_consumer.go
@@ -86,6 +86,13 @@ type ProducerConsumerJob[T any] struct {
 // metric. At runtime, `nil` can be given to use the default registry. In
 // tests, a test-local prometheus.Registry instance should be used instead.
 func (j *ProducerConsumerJob[T]) Setup(registerer prometheus.Registerer) Job {
+	if j.DiscoverTask == nil {
+		panic("DiscoverTask must be set!")
+	}
+	if j.ProcessTask == nil {
+		panic("ProcessTask must be set!")
+	}
+
 	j.Metadata.setup(registerer)
 	// NOTE: We wrap `j` into a private type instead of implementing the
 	// Job interface directly on `j` to enforce that callers run Setup().

--- a/jobloop/tx_guarded.go
+++ b/jobloop/tx_guarded.go
@@ -84,6 +84,16 @@ type TxGuardedJob[Tx sqlext.Rollbacker, P any] struct {
 // metric. At runtime, `nil` can be given to use the default registry. In
 // tests, a test-local prometheus.Registry instance should be used instead.
 func (j *TxGuardedJob[Tx, P]) Setup(registerer prometheus.Registerer) Job {
+	if j.BeginTx == nil {
+		panic("BeginTx must be set!")
+	}
+	if j.DiscoverRow == nil {
+		panic("DiscoverRow must be set!")
+	}
+	if j.ProcessRow == nil {
+		panic("ProcessRow must be set!")
+	}
+
 	return (&ProducerConsumerJob[*txGuardedTask[Tx, P]]{
 		Metadata:     j.Metadata,
 		DiscoverTask: j.discoverTask,


### PR DESCRIPTION
This makes runtime errors as the following easier to find and fix:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xabc514]

goroutine 152 [running]:
github.com/sapcc/go-bits/jobloop.(*TxGuardedJob[...]).discoverTask(0xe28c80, 0xc1ed80)
        /src/vendor/github.com/sapcc/go-bits/jobloop/tx_guarded.go:102 +0x74
github.com/sapcc/go-bits/jobloop.(*ProducerConsumerJob[...]).produceOne(0x10)
        /src/vendor/github.com/sapcc/go-bits/jobloop/producer_consumer.go:103 +0xe8
github.com/sapcc/go-bits/jobloop.producerConsumerJobImpl[...].ProcessOne(0xe2c320?)
        /src/vendor/github.com/sapcc/go-bits/jobloop/producer_consumer.go:126 +0x29
github.com/sapcc/go-bits/jobloop.producerConsumerJobImpl[...].runSingleThreaded(0xe2c320?, {0xe22b30, 0xc0001251d0})
        /src/vendor/github.com/sapcc/go-bits/jobloop/producer_consumer.go:153 +0x3d
github.com/sapcc/go-bits/jobloop.producerConsumerJobImpl[...].Run(0xe2c320?, {0xe22b30, 0xc0001251d0}, {0x0, 0x0, 0x0})
        /src/vendor/github.com/sapcc/go-bits/jobloop/producer_consumer.go:141 +0xcf
created by github.com/sapcc/keppel/cmd/janitor.run
        /src/cmd/janitor/main.go:87 +0xab0
```