### PR TITLE
audittools: add persistence to publishing

### DIFF
--- a/audittools/rabbitmq.go
+++ b/audittools/rabbitmq.go
@@ -112,8 +112,9 @@ func (c *RabbitConnection) PublishEvent(event *cadf.Event) error {
 		false,       // mandatory: don't publish if no queue is bound that matches the routing key
 		false,       // immediate: don't publish if no consumer on the matched queue is ready to accept the delivery
 		amqp.Publishing{
-			ContentType: "text/plain",
-			Body:        b,
+			ContentType:  "text/plain",
+			Body:         b,
+			DeliveryMode: amqp.Persistent, // Ensure message persistence
 		},
 	)
 }


### PR DESCRIPTION
We use persistence with our rabbitmq clusters, this must be set as persistent when publishing.