### PR TITLE
Add handling to empty prometheus queries

### DIFF
--- a/promquery/bulkquerycache.go
+++ b/promquery/bulkquerycache.go
@@ -20,7 +20,6 @@ package promquery
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -106,7 +105,7 @@ func (c *BulkQueryCache[K, V]) fillCacheIfNecessary(ctx context.Context) error {
 		}
 		// prevent empty prometheus results from being processed downstream.
 		if len(vector) == 0 {
-			return errors.New("did not receive any values from prometheus")
+			return fmt.Errorf("did not receive any values from prometheus for %s", q.Description)
 		}
 		for _, sample := range vector {
 			key := q.Keyer(sample)

--- a/promquery/bulkquerycache.go
+++ b/promquery/bulkquerycache.go
@@ -20,6 +20,7 @@ package promquery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -102,6 +103,10 @@ func (c *BulkQueryCache[K, V]) fillCacheIfNecessary(ctx context.Context) error {
 		vector, err := c.client.GetVector(ctx, q.Query)
 		if err != nil {
 			return fmt.Errorf("cannot collect %s: %w", q.Description, err)
+		}
+		// prevent empty prometheus results from being processed downstream.
+		if len(vector) == 0 {
+			return errors.New("did not receive any values from prometheus")
 		}
 		for _, sample := range vector {
 			key := q.Keyer(sample)


### PR DESCRIPTION
This PR aims to prevent the processing of empty prometheus query results in applications that use this library. A scenario was sighted in Limes where the source applications did not provide data to prometheus for a certain time period.