### PR TITLE
liquidapi: add GET /healthcheck

### DIFF
--- a/liquidapi/liquidapi.go
+++ b/liquidapi/liquidapi.go
@@ -206,6 +206,7 @@ func Run(ctx context.Context, logic Logic, opts RunOpts) error {
 	muxer := http.NewServeMux()
 	muxer.Handle("/", httpapi.Compose(
 		rt,
+		httpapi.HealthCheckAPI{SkipRequestLog: true},
 		httpapi.WithGlobalMiddleware(limitRequestsMiddleware(opts.MaxConcurrentRequests)),
 	))
 	muxer.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
I initially thought to use GET /v1/info for Kubernetes probes, but that does not work because the kubelet does not have a Keystone token.