### PR TITLE
assert: ensure that both sides of DeepEqual() are of the same type

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -31,7 +31,7 @@ import (
 
 // DeepEqual checks if the actual and expected value are equal as
 // determined by reflect.DeepEqual(), and t.Error()s otherwise.
-func DeepEqual(t *testing.T, variable string, actual, expected any) bool {
+func DeepEqual[V any](t *testing.T, variable string, actual, expected V) bool {
 	t.Helper()
 	if reflect.DeepEqual(actual, expected) {
 		return true

--- a/errext/errext_test.go
+++ b/errext/errext_test.go
@@ -31,7 +31,7 @@ func TestAsAndIs(t *testing.T) {
 
 	// unwrapped error can be type-casted
 	ferr, ok := As[fooError](err1)
-	assert.DeepEqual(t, "As", ferr, err1)
+	assert.DeepEqual(t, "As", ferr.Data, 23)
 	assert.DeepEqual(t, "As", ok, true)
 	ok = IsOfType[fooError](err1)
 	assert.DeepEqual(t, "As", ok, true)
@@ -46,7 +46,7 @@ func TestAsAndIs(t *testing.T) {
 
 	// wrapped error can be type-casted
 	ferr, ok = As[fooError](err2)
-	assert.DeepEqual(t, "As", ferr, err1)
+	assert.DeepEqual(t, "As", ferr.Data, 23)
 	assert.DeepEqual(t, "As", ok, true)
 	ok = IsOfType[fooError](err1)
 	assert.DeepEqual(t, "As", ok, true)

--- a/osext/env_test.go
+++ b/osext/env_test.go
@@ -51,7 +51,7 @@ func TestGetenv(t *testing.T) {
 	t.Setenv(KEY, "")
 
 	_, err = osext.NeedGetenv(KEY)
-	assert.DeepEqual(t, "error from NeedGetenv", err, osext.MissingEnvError{Key: KEY})
+	assert.DeepEqual(t, "error from NeedGetenv", err, error(osext.MissingEnvError{Key: KEY}))
 
 	str = osext.GetenvOrDefault(KEY, DEFAULT)
 	assert.DeepEqual(t, "result from GetenvOrDefault", str, DEFAULT)
@@ -63,7 +63,7 @@ func TestGetenv(t *testing.T) {
 	os.Unsetenv(KEY)
 
 	_, err = osext.NeedGetenv(KEY)
-	assert.DeepEqual(t, "error from NeedGetenv", err, osext.MissingEnvError{Key: KEY})
+	assert.DeepEqual(t, "error from NeedGetenv", err, error(osext.MissingEnvError{Key: KEY}))
 
 	str = osext.GetenvOrDefault(KEY, DEFAULT)
 	assert.DeepEqual(t, "result from GetenvOrDefault", str, DEFAULT)


### PR DESCRIPTION
If both sides are of different types, then `reflect.DeepEqual()` will always fail. This looks like something that we ought to detect on the type level.