### PR TITLE
gopherpolicy: remove explicit YAML dependency

### DIFF
--- a/liquidapi/liquidapi.go
+++ b/liquidapi/liquidapi.go
@@ -84,6 +84,11 @@ type RunOpts struct {
 	// the Logic instance to supply configuration to it, before Init() is called.
 	TakesConfiguration bool
 
+	// If set, when the runtime loads its oslo.policy from $LIQUID_POLICY_PATH,
+	// YAML will be supported in addition to JSON. This is an explicit dependency
+	// injection slot to allow the caller to choose their YAML library.
+	YAMLUnmarshal func(in []byte, out any) error
+
 	// How often the runtime will call BuildServiceInfo() to refresh the
 	// ServiceInfo of the liquid. The zero value can be used for liquids with
 	// static ServiceInfo; no polling will be performed then.
@@ -177,7 +182,7 @@ func Run(ctx context.Context, logic Logic, opts RunOpts) error {
 	if err != nil {
 		return err
 	}
-	err = tv.LoadPolicyFile(policyPath)
+	err = tv.LoadPolicyFile(policyPath, opts.YAMLUnmarshal)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Callers can still support policy.yaml files, but they have to explicitly provide a YAML parser function of their choice.

The change in package gopherpolicy is explicitly designed to be loud and obvious when Renovate tries to update, because the function signature changes. Unfortunately, I did not see a good way to make the change in package liquidapi similarly loud and obvious. But since this currently only affects Limes (which is under my control) and liquid-ceph (which we have a direct line of communication to), this ought to be manageable.