### PR TITLE
gophercloudext: add ClientOpts.CustomizeAuthOptions

### DIFF
--- a/easypg/snapshot.go
+++ b/easypg/snapshot.go
@@ -203,7 +203,7 @@ func newTableSnapshot(t *testing.T, db *sql.DB, tableName string, keyColumnNames
 		failOnErr(t, rows.Scan(scanTarget...))
 		row := make(rowSnapshot, len(columnNames))
 		for idx, columnName := range columnNames {
-			row[columnName] = scanTarget[idx].(*sqlValueSerializer).Serialized
+			row[columnName] = scanTarget[idx].(*sqlValueSerializer).Serialized //nolint:errcheck // this type assertion cannot fail because of how the slice is constructed
 		}
 		result.Rows[row.Key(result.KeyColumnNames)] = row
 	}

--- a/gophercloudext/auth.go
+++ b/gophercloudext/auth.go
@@ -50,6 +50,13 @@ type ClientOpts struct {
 	// gophercloud.ProviderClient insists on taking ownership of whatever is
 	// given here, so we cannot just give http.DefaultClient here.
 	HTTPClient *http.Client
+
+	// CustomizeAuthOptions is a callback that can be used to modify the
+	// constructed AuthOptions before they are passed to the ProviderClient.
+	//
+	// This is used in rare special cases, e.g. when an application needs to
+	// spawn clients with different token scopes for specific operations.
+	CustomizeAuthOptions func(*gophercloud.AuthOptions)
 }
 
 // NewProviderClient authenticates with OpenStack using the credentials found
@@ -127,6 +134,9 @@ func NewProviderClient(ctx context.Context, optsPtr *ClientOpts) (*gophercloud.P
 		Scope:                       &scope,
 		ApplicationCredentialID:     os.Getenv(opts.EnvPrefix + "APPLICATION_CREDENTIAL_ID"),
 		ApplicationCredentialSecret: os.Getenv(opts.EnvPrefix + "APPLICATION_CREDENTIAL_SECRET"),
+	}
+	if opts.CustomizeAuthOptions != nil {
+		opts.CustomizeAuthOptions(&ao)
 	}
 
 	provider, err := openstack.NewClient(ao.IdentityEndpoint)


### PR DESCRIPTION
Castellum needs a special affordance here because it wants to be able to use its cloud_admin credentials to scope into customer projects for some specific operations. For reference:

https://github.com/sapcc/castellum/blob/5cdaf93ae7dc65ac6e2cb426cd0875aac15e13d1/internal/core/openstack.go#L138-L152