### PR TITLE
liquidapi: replace gophercloud/utils with gophercloudext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gofrs/uuid/v5 v5.3.0
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/gophercloud/gophercloud/v2 v2.2.0
-	github.com/gophercloud/utils/v2 v2.0.0-20241021065553-b46d0737ee98
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gophercloud/gophercloud/v2 v2.2.0 h1:STqqnSXuhcg1OPBOZ14z6JDm8fKIN13H2bJg6bBuHp8=
 github.com/gophercloud/gophercloud/v2 v2.2.0/go.mod h1:f2hMRC7Kakbv5vM7wSGHrIPZh6JZR60GVHryJlF/K44=
-github.com/gophercloud/utils/v2 v2.0.0-20241021065553-b46d0737ee98 h1:4/3x+yL9lcaV1lzwolxOSp/tHVSjn9S+yXh0NiX/vFQ=
-github.com/gophercloud/utils/v2 v2.0.0-20241021065553-b46d0737ee98/go.mod h1:9KHhEdDkA/4hTdwxS0sALJIp2hFSjrODlKMQcFU2GFw=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/liquidapi/liquidapi.go
+++ b/liquidapi/liquidapi.go
@@ -40,11 +40,11 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
-	"github.com/gophercloud/utils/v2/openstack/clientconfig"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sapcc/go-api-declarations/liquid"
 
+	"github.com/sapcc/go-bits/gophercloudext"
 	"github.com/sapcc/go-bits/gopherpolicy"
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/httpext"
@@ -155,18 +155,9 @@ func Run(ctx context.Context, logic Logic, opts RunOpts) error {
 	}
 
 	// connect to OpenStack
-	ao, err := clientconfig.AuthOptions(nil)
+	provider, eo, err := gophercloudext.NewProviderClient(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("cannot find OpenStack credentials: %w", err)
-	}
-	ao.AllowReauth = true
-	provider, err := openstack.AuthenticatedClient(ctx, *ao)
-	if err != nil {
-		return fmt.Errorf("cannot initialize OpenStack client: %w", err)
-	}
-	eo := gophercloud.EndpointOpts{
-		Availability: gophercloud.Availability(os.Getenv("OS_INTERFACE")),
-		Region:       os.Getenv("OS_REGION_NAME"),
+		return err
 	}
 
 	// initialize TokenValidator


### PR DESCRIPTION
So I was wondering why `gophercloud/utils` was not dropped when I switched Limes to gophercloudext. This is why. :)