### PR TITLE
audittools: fix gopherpolicy integration

### DIFF
--- a/audittools/event_test.go
+++ b/audittools/event_test.go
@@ -1,0 +1,24 @@
+/******************************************************************************
+*
+*  Copyright 2024 SAP SE
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+******************************************************************************/
+
+package audittools
+
+import "github.com/sapcc/go-bits/gopherpolicy"
+
+// check that *gopherpolicy.Token implements the UserInfo interface
+var _ UserInfo = &gopherpolicy.Token{}

--- a/gopherpolicy/token.go
+++ b/gopherpolicy/token.go
@@ -158,7 +158,7 @@ func (t *Token) AsInitiator(host cadf.Host) cadf.Resource {
 		Name:   t.UserName(),
 		Domain: t.UserDomainName(),
 		ID:     t.UserUUID(),
-		Host:   nil, // NOTE: will be filled in package audittools based on HTTP request metadata
+		Host:   &host,
 		// information about user's scope (only one of both will be filled)
 		DomainID:          t.DomainScopeUUID(),
 		DomainName:        t.DomainScopeName(),


### PR DESCRIPTION
I was in the process of reworking the dataflow and forgot to match the change on the gopherpolicy side with the audittools side.

To remedy this, an assertion has been added to check that gopherpolicy.Token satisfies the audittools.UserInfo interface.