### PR TITLE
easypg: stop database connection if not existed properly

### DIFF
--- a/easypg/testsetup.go
+++ b/easypg/testsetup.go
@@ -99,7 +99,7 @@ func WithTestDB(m *testing.M, action func() int) int {
 	if _, err := os.Stat(filepath.Join(rootPath, ".testdb/run/pid")); err == nil {
 		err := stopDatabaseConnection(rootPath)
 		if err != nil {
-			logg.Error("could not run pg_ctl stop: %s", err.Error())
+			logg.Error(err.Error())
 		}
 	}
 
@@ -131,7 +131,7 @@ func WithTestDB(m *testing.M, action func() int) int {
 	// stop database process (regardless of whether tests succeeded or failed!)
 	err = stopDatabaseConnection(rootPath)
 	if err != nil {
-		logg.Fatal("could not run pg_ctl stop: %s", err.Error())
+		logg.Fatal(err.Error())
 	}
 
 	return exitCode
@@ -145,7 +145,10 @@ func stopDatabaseConnection(rootPath string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
-	return err
+	if err != nil {
+		return fmt.Errorf("could not run pg_ctl stop: %w", err)
+	}
+	return nil
 }
 
 func findRepositoryRootDir() (string, error) {

--- a/easypg/testsetup.go
+++ b/easypg/testsetup.go
@@ -95,6 +95,11 @@ func WithTestDB(m *testing.M, action func() int) int {
 		}
 	}
 
+	// check if a previous connection is still lingering
+	if _, err := os.Stat(filepath.Join(rootPath, ".testdb/run/pid")); err == nil {
+		stopDatabaseConnection(rootPath)
+	}
+
 	// drop helper scripts that can be used to attach to the test DB for manual debugging and inspection
 	for _, clientTool := range []string{"psql", "pgcli", "pg_dump"} {
 		path := filepath.Join(rootPath, ".testdb", clientTool+".sh")
@@ -121,18 +126,22 @@ func WithTestDB(m *testing.M, action func() int) int {
 	hasTestDB = false
 
 	// stop database process (regardless of whether tests succeeded or failed!)
-	cmd = exec.Command("pg_ctl", "stop", "--wait", "--silent", //nolint:gosec // rule G204 is overly broad
+	stopDatabaseConnection(rootPath)
+
+	return exitCode
+}
+
+func stopDatabaseConnection(rootPath string) {
+	cmd := exec.Command("pg_ctl", "stop", "--wait", "--silent", //nolint:gosec // rule G204 is overly broad
 		"-D", filepath.Join(rootPath, ".testdb/datadir"),
 	)
 	cmd.Stdin = nil
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
 		logg.Fatal("could not run pg_ctl stop: %s", err.Error())
 	}
-
-	return exitCode
 }
 
 func findRepositoryRootDir() (string, error) {

--- a/easypg/testsetup.go
+++ b/easypg/testsetup.go
@@ -97,7 +97,7 @@ func WithTestDB(m *testing.M, action func() int) int {
 
 	// check if a previous connection is still lingering
 	if _, err := os.Stat(filepath.Join(rootPath, ".testdb/run/pid")); err == nil {
-		err := stopDatabaseConnection(rootPath)
+		err := stopDatabaseServer(rootPath)
 		if err != nil {
 			logg.Error(err.Error())
 		}
@@ -129,7 +129,7 @@ func WithTestDB(m *testing.M, action func() int) int {
 	hasTestDB = false
 
 	// stop database process (regardless of whether tests succeeded or failed!)
-	err = stopDatabaseConnection(rootPath)
+	err = stopDatabaseServer(rootPath)
 	if err != nil {
 		logg.Fatal(err.Error())
 	}
@@ -137,7 +137,7 @@ func WithTestDB(m *testing.M, action func() int) int {
 	return exitCode
 }
 
-func stopDatabaseConnection(rootPath string) error {
+func stopDatabaseServer(rootPath string) error {
 	cmd := exec.Command("pg_ctl", "stop", "--wait", "--silent", //nolint:gosec // rule G204 is overly broad
 		"-D", filepath.Join(rootPath, ".testdb/datadir"),
 	)

--- a/easypg/testsetup.go
+++ b/easypg/testsetup.go
@@ -97,7 +97,10 @@ func WithTestDB(m *testing.M, action func() int) int {
 
 	// check if a previous connection is still lingering
 	if _, err := os.Stat(filepath.Join(rootPath, ".testdb/run/pid")); err == nil {
-		stopDatabaseConnection(rootPath)
+		err := stopDatabaseConnection(rootPath)
+		if err != nil {
+			logg.Error("could not run pg_ctl stop: %s", err.Error())
+		}
 	}
 
 	// drop helper scripts that can be used to attach to the test DB for manual debugging and inspection
@@ -126,12 +129,15 @@ func WithTestDB(m *testing.M, action func() int) int {
 	hasTestDB = false
 
 	// stop database process (regardless of whether tests succeeded or failed!)
-	stopDatabaseConnection(rootPath)
+	err = stopDatabaseConnection(rootPath)
+	if err != nil {
+		logg.Fatal("could not run pg_ctl stop: %s", err.Error())
+	}
 
 	return exitCode
 }
 
-func stopDatabaseConnection(rootPath string) {
+func stopDatabaseConnection(rootPath string) error {
 	cmd := exec.Command("pg_ctl", "stop", "--wait", "--silent", //nolint:gosec // rule G204 is overly broad
 		"-D", filepath.Join(rootPath, ".testdb/datadir"),
 	)
@@ -139,9 +145,7 @@ func stopDatabaseConnection(rootPath string) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
-	if err != nil {
-		logg.Fatal("could not run pg_ctl stop: %s", err.Error())
-	}
+	return err
 }
 
 func findRepositoryRootDir() (string, error) {


### PR DESCRIPTION
This is something I noticed during local test execution. If the application crashes or the test execution gets exited prematurely, the previous DB connection still lingers around which forces an execution error.