### PR TITLE
liquid: import various algorithms and utils from package limes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ reusability. Feel free to add to this.
 * [httpapi](./httpapi) contains opinionated base machinery for assembling and exposing an API consisting of HTTP endpoints.
 * [httpext](./httpext) adds some convenience functions to [net/http](https://golang.org/pkg/http/).
 * [jobloop](./jobloop) contains the Job trait, which abstracts over reusable implementations of worker loops.
-* [liquidapi](./liquidapi) is a server runtime for microservices implementing [LIQUID API](https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid).
+* [liquidapi](./liquidapi) contains a server runtime and various other utilities for microservices implementing the [LIQUID API](https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid).
 * [logg](./logg) adds some convenience functions to [log](https://golang.org/pkg/log/).
 * [mock](./mock) contains basic mocks and test doubles.
 * [must](./must) contains convenience functions for quickly exiting on fatal errors without the need for excessive `if err != nil`.

--- a/gophercloudext/auth.go
+++ b/gophercloudext/auth.go
@@ -18,7 +18,8 @@
 *******************************************************************************/
 
 // Package gophercloudext contains convenience functions for use with [Gophercloud].
-// It is specifically intended as a lightweight replacement for [gophercloud/utils] with fewer dependencies.
+// Its func NewProviderClient is specifically intended as a lightweight replacement for [gophercloud/utils] with fewer dependencies,
+// but there are also other generalized utility functions.
 //
 // [Gophercloud]: https://github.com/gophercloud/gophercloud
 // [gophercloud/utils]: https://github.com/gophercloud/utils

--- a/gophercloudext/utils.go
+++ b/gophercloudext/utils.go
@@ -1,0 +1,47 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package gophercloudext
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+)
+
+// GetProjectIDFromTokenScope returns the project ID from the client's token scope.
+//
+// This is useful in applications that usually operate on the cloud-admin level,
+// when using an API endpoint that requires a project ID in its URL.
+// Usually this is then overridden by a query parameter like "?all_projects=True".
+func GetProjectIDFromTokenScope(provider *gophercloud.ProviderClient) (string, error) {
+	result, ok := provider.GetAuthResult().(tokens.CreateResult)
+	if !ok {
+		return "", fmt.Errorf("%T is not a %T", provider.GetAuthResult(), tokens.CreateResult{})
+	}
+	project, err := result.ExtractProject()
+	if err != nil {
+		return "", err
+	}
+	if project == nil || project.ID == "" {
+		return "", fmt.Errorf(`expected "id" attribute in "project" section, but got %#v`, project)
+	}
+	return project.ID, nil
+}

--- a/liquidapi/algorithms.go
+++ b/liquidapi/algorithms.go
@@ -1,0 +1,183 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquidapi
+
+import (
+	"encoding/json"
+	"math"
+	"slices"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+
+	"github.com/sapcc/go-bits/logg"
+)
+
+// DistributeFairly takes a number of resource requests, as well as a total
+// available capacity, and tries to fulfil all requests as fairly as possible.
+//
+// If the sum of all requests exceeds the available total, this uses the
+// <https://en.wikipedia.org/wiki/Largest_remainder_method>.
+func DistributeFairly[K comparable](total uint64, requested map[K]uint64) map[K]uint64 {
+	// easy case: all requests can be granted
+	sumOfRequests := uint64(0)
+	for _, request := range requested {
+		sumOfRequests += request
+	}
+	if sumOfRequests <= total {
+		return requested
+	}
+
+	// a completely fair distribution would require using these floating-point values...
+	exact := make(map[K]float64, len(requested))
+	for key, request := range requested {
+		exact[key] = float64(total) * float64(request) / float64(sumOfRequests)
+	}
+
+	// ...but we have to round to uint64
+	fair := make(map[K]uint64, len(requested))
+	keys := make([]K, 0, len(requested))
+	totalOfFair := uint64(0)
+	for key := range requested {
+		floor := uint64(math.Floor(exact[key]))
+		fair[key] = floor
+		totalOfFair += floor
+		keys = append(keys, key)
+	}
+
+	// now we have `sum(fair) <= total` because the fractional parts were ignored;
+	// to fix this, we distribute one more to the highest fractional parts, e.g.
+	//
+	//    total = 15
+	//    requested = [ 4, 6, 7 ]
+	//    exact = [ 3.529..., 5.294..., 6.176... ]
+	//    fair before adjustment = [ 3, 5, 6 ]
+	//    missing = 1
+	//    fair after adjustment = [ 4, 5, 6 ] -> because exact[0] had the largest fractional part
+	//
+	missing := total - totalOfFair
+	slices.SortFunc(keys, func(lhs, rhs K) int {
+		leftRemainder := exact[lhs] - math.Floor(exact[lhs])
+		rightRemainder := exact[rhs] - math.Floor(exact[rhs])
+		switch {
+		case leftRemainder < rightRemainder:
+			return -1
+		case leftRemainder > rightRemainder:
+			return +1
+		default:
+			return 0
+		}
+	})
+	for _, key := range keys[len(keys)-int(missing):] { //nolint:gosec // algorithm ensures that no overflow happens on uint64 -> int cast
+		fair[key] += 1
+	}
+	return fair
+}
+
+// DistributeDemandFairly is used to distribute cluster capacity or cluster-wide usage between different resources.
+// Each tier of demand is distributed fairly (while supplies last).
+//
+// Then anything not yet distributed is split according to the given balance numbers.
+// For example, if balance = { "foo": 3, "bar": 1 }, then "foo" gets 3/4 of the remaining capacity, "bar" gets 1/4, and all other resources do not get anything extra.
+func DistributeDemandFairly[K comparable](total uint64, demands map[K]liquid.ResourceDemandInAZ, balance map[K]float64) map[K]uint64 {
+	// setup phase to make each of the paragraphs below as identical as possible (for clarity)
+	requests := make(map[K]uint64)
+	result := make(map[K]uint64)
+	remaining := total
+
+	// tier 1: usage
+	for k, demand := range demands {
+		requests[k] = demand.Usage
+	}
+	grantedAmount := DistributeFairly(remaining, requests)
+	for k := range demands {
+		remaining -= grantedAmount[k]
+		result[k] += grantedAmount[k]
+	}
+	if logg.ShowDebug {
+		resultJSON, err := json.Marshal(result)
+		if err == nil {
+			logg.Debug("DistributeDemandFairly after phase 1: " + string(resultJSON))
+		}
+	}
+
+	// tier 2: unused commitments
+	for k, demand := range demands {
+		requests[k] = demand.UnusedCommitments
+	}
+	grantedAmount = DistributeFairly(remaining, requests)
+	for k := range demands {
+		remaining -= grantedAmount[k]
+		result[k] += grantedAmount[k]
+	}
+	if logg.ShowDebug {
+		resultJSON, err := json.Marshal(result)
+		if err == nil {
+			logg.Debug("DistributeDemandFairly after phase 2: " + string(resultJSON))
+		}
+	}
+
+	// tier 3: pending commitments
+	for k, demand := range demands {
+		requests[k] = demand.PendingCommitments
+	}
+	grantedAmount = DistributeFairly(remaining, requests)
+	for k := range demands {
+		remaining -= grantedAmount[k]
+		result[k] += grantedAmount[k]
+	}
+	if logg.ShowDebug {
+		resultJSON, err := json.Marshal(result)
+		if err == nil {
+			logg.Debug("DistributeDemandFairly after phase 3: " + string(resultJSON))
+		}
+	}
+
+	// final phase: distribute remainder according to the given balance
+	if remaining == 0 {
+		return result
+	}
+	for k := range demands {
+		// This requests incorrect ratios if `remaining` and `balance[k]` are so
+		// large that `balance[k] * remaining` falls outside the range of uint64.
+		//
+		// I'm accepting this since this scenario is very unlikely, and only made
+		// sure that there are no weird overflows, truncations and such.
+		requests[k] = clampFloatToUint64(balance[k] * float64(remaining))
+	}
+	grantedAmount = DistributeFairly(remaining, requests)
+	for k := range demands {
+		remaining -= grantedAmount[k]
+		result[k] += grantedAmount[k]
+	}
+	if logg.ShowDebug {
+		resultJSON, err := json.Marshal(result)
+		if err == nil {
+			logg.Debug("DistributeDemandFairly after balance: " + string(resultJSON))
+		}
+	}
+
+	return result
+}
+
+func clampFloatToUint64(x float64) uint64 {
+	x = max(x, 0)
+	x = min(x, math.MaxUint64)
+	return uint64(x)
+}

--- a/liquidapi/algorithms_test.go
+++ b/liquidapi/algorithms_test.go
@@ -1,0 +1,152 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquidapi
+
+import (
+	"testing"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+
+	"github.com/sapcc/go-bits/assert"
+)
+
+// NOTE: Additional test coverage for DistributeFairly() is implicit as part of datamodel.ApplyComputedProjectQuota() in Limes.
+
+func TestDistributeFairlyWithLargeNumbers(t *testing.T) {
+	// This tests how DistributeFairly() deals with very large numbers
+	// (as can occur e.g. for Swift capacity measured in bytes).
+	// We used to have a crash here because of an overflowing uint64 multiplication.
+	total := uint64(200000000000000)
+	requested := map[uint16]uint64{
+		401: total / 2,
+		402: total / 2,
+		403: total / 2,
+		404: total / 2,
+	}
+	result := DistributeFairly(total, requested)
+	assert.DeepEqual(t, "output of DistributeFairly", result, map[uint16]uint64{
+		401: total / 4,
+		402: total / 4,
+		403: total / 4,
+		404: total / 4,
+	})
+}
+
+func TestDistributeDemandFairlyWithJustBalance(t *testing.T) {
+	// no demand, just balance
+	total := uint64(400)
+	demands := map[string]liquid.ResourceDemandInAZ{
+		"foo": {},
+		"bar": {},
+	}
+	balance := map[string]float64{
+		"foo": 2,
+		"bar": 1,
+	}
+	result := DistributeDemandFairly(total, demands, balance)
+	assert.DeepEqual(t, "output of DistributeDemandFairly", result, map[string]uint64{
+		"foo": 267,
+		"bar": 133,
+	})
+}
+
+func TestDistributeDemandFairlyWithIncreasingCapacity(t *testing.T) {
+	// This test uses the same demands and balance throughout, but capacity
+	// increases over time to test how different types of demand are considered
+	// in order.
+	demands := map[string]liquid.ResourceDemandInAZ{
+		"first": {
+			Usage:              500,
+			UnusedCommitments:  50,
+			PendingCommitments: 10,
+		},
+		"second": {
+			Usage:              300,
+			UnusedCommitments:  200,
+			PendingCommitments: 20,
+		},
+		"third": {
+			Usage:              0,
+			UnusedCommitments:  100,
+			PendingCommitments: 70,
+		},
+	}
+	balance := map[string]float64{
+		"first":  0,
+		"second": 1,
+		"third":  1,
+	}
+
+	// usage cannot be covered
+	result := DistributeDemandFairly(200, demands, balance)
+	assert.DeepEqual(t, "output of DistributeDemandFairly", result, map[string]uint64{
+		"first":  125,
+		"second": 75,
+		"third":  0,
+	})
+
+	// usage is exactly covered
+	result = DistributeDemandFairly(800, demands, balance)
+	assert.DeepEqual(t, "output of DistributeDemandFairly", result, map[string]uint64{
+		"first":  500,
+		"second": 300,
+		"third":  0,
+	})
+
+	// unused commitments cannot be covered
+	result = DistributeDemandFairly(900, demands, balance)
+	assert.DeepEqual(t, "output of DistributeDemandFairly", result, map[string]uint64{
+		"first":  514,
+		"second": 357,
+		"third":  29,
+	})
+
+	// unused commitments are exactly covered
+	result = DistributeDemandFairly(1150, demands, balance)
+	assert.DeepEqual(t, "output of DistributeDemandFairly", result, map[string]uint64{
+		"first":  550,
+		"second": 500,
+		"third":  100,
+	})
+
+	// pending commitments cannot be covered
+	result = DistributeDemandFairly(1160, demands, balance)
+	assert.DeepEqual(t, "output of DistributeDemandFairly", result, map[string]uint64{
+		"first":  551,
+		"second": 502,
+		"third":  107,
+	})
+
+	// unused commitments are exactly covered
+	result = DistributeDemandFairly(1250, demands, balance)
+	assert.DeepEqual(t, "output of DistributeDemandFairly", result, map[string]uint64{
+		"first":  560,
+		"second": 520,
+		"third":  170,
+	})
+
+	// extra capacity is distributed according to balance
+	result = DistributeDemandFairly(2250, demands, balance)
+	assert.DeepEqual(t, "output of DistributeDemandFairly", result, map[string]uint64{
+		"first":  560,
+		"second": 1020,
+		"third":  670,
+	})
+}

--- a/liquidapi/doc.go
+++ b/liquidapi/doc.go
@@ -1,0 +1,26 @@
+/*******************************************************************************
+*
+* Copyright 2025 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+// Package liquidapi provides a runtime library for servers and clients implementing the LIQUID protocol:
+// <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>
+//
+//   - func Run() provides a full-featured runtime that handles OpenStack credentials, authorization, and more.
+//   - type Client is a specialized gophercloud.ServiceClient for use in Limes and limesctl.
+//   - The other functions in this package contain various numeric algorithms that are useful for LIQUID implementations.
+package liquidapi

--- a/liquidapi/liquidapi.go
+++ b/liquidapi/liquidapi.go
@@ -17,15 +17,6 @@
 *
 *******************************************************************************/
 
-// Package liquidapi provides a runtime for servers that implement the LIQUID
-// API and nothing else. The application will only have to provide a type that
-// implements the Logic interface. Then it can call Run() on an instance of it
-// to parse configuration, connect to OpenStack and run the HTTP server.
-//
-// Ref: <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>
-//
-// This package also provides a Gophercloud-based Client for talking to the
-// LIQUID API. Realistically, only Limes and limesctl will need this though. :)
 package liquidapi
 
 import (
@@ -67,6 +58,11 @@ type Logic interface {
 	// periodically (as configured in RunOpts). The previous ServiceInfo will be
 	// served until this call returns, so it's not a big deal if this call takes
 	// a long time.
+	//
+	// If any long-lived state is computed here and needs to be preserved,
+	// in addition to the information stored in the ServiceInfo instance,
+	// we recommend adding fields of type liquidapi.State to the Logic object.
+	// Then, only fill these state slots immediately before returning success from BuildServiceInfo.
 	BuildServiceInfo(ctx context.Context) (liquid.ServiceInfo, error)
 
 	// These methods represent all the API endpoints of LIQUID that do actual work.
@@ -74,6 +70,9 @@ type Logic interface {
 	// The latest ServiceInfo is provided for reference. Only a shallow copy is
 	// provided, so implementations must make sure to not edit the ServiceInfo in
 	// order to uphold thread-safety.
+	//
+	// All these functions should not store long-lived state in the Logic object.
+	// Long-lived state should only be computed and updated during BuildServiceInfo().
 	ScanCapacity(ctx context.Context, req liquid.ServiceCapacityRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceCapacityReport, error)
 	ScanUsage(ctx context.Context, projectUUID string, req liquid.ServiceUsageRequest, serviceInfo liquid.ServiceInfo) (liquid.ServiceUsageReport, error)
 	SetQuota(ctx context.Context, projectUUID string, req liquid.ServiceQuotaRequest, serviceInfo liquid.ServiceInfo) error

--- a/liquidapi/utils.go
+++ b/liquidapi/utils.go
@@ -1,0 +1,85 @@
+/*******************************************************************************
+*
+* Copyright 2024 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package liquidapi
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/sapcc/go-api-declarations/liquid"
+)
+
+// RestrictToKnownAZs takes a mapping of objects sorted by AZ,
+// and moves all objects in unknown AZs into the pseudo-AZ "unknown".
+//
+// The resulting map will have an entry for each known AZ (possibly a nil slice),
+// and at most one additional key (the well-known value "unknown").
+func RestrictToKnownAZs[T any](input map[liquid.AvailabilityZone][]T, allAZs []liquid.AvailabilityZone) map[liquid.AvailabilityZone][]T {
+	output := make(map[liquid.AvailabilityZone][]T, len(allAZs))
+	for _, az := range allAZs {
+		output[az] = input[az]
+	}
+	for az, items := range input {
+		if !slices.Contains(allAZs, az) {
+			output[liquid.AvailabilityZoneUnknown] = append(output[liquid.AvailabilityZoneUnknown], items...)
+		}
+	}
+	return output
+}
+
+// SaturatingSub is like `lhs - rhs`, but never underflows below 0.
+func SaturatingSub[T interface{ int | uint64 }](lhs, rhs T) uint64 {
+	if lhs < rhs {
+		return 0
+	}
+	return uint64(lhs - rhs)
+}
+
+// AtLeastZero safely converts int values (which often appear in Gophercloud types) to uint64 by clamping negative values to 0.
+func AtLeastZero(x int) uint64 {
+	if x < 0 {
+		return 0
+	}
+	return uint64(x)
+}
+
+// State contains data that is guarded by an RWMutex, such that the data cannot be accessed without using the mutex.
+// A zero-initialized State contains a zero-initialized piece of data.
+//
+// This is provided here for implementations of the Logic interface that compute state during BuildServiceInfo().
+// See documentation on type Logic.
+type State[T any] struct {
+	mutex sync.RWMutex
+	data  T
+}
+
+// Set replaces the contained value.
+func (s *State[T]) Set(value T) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.data = value
+}
+
+// Get returns a shallow copy of the contained value.
+func (s *State[T]) Get() T {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.data
+}


### PR DESCRIPTION
To make these utility functions available to external LIQUID implementors, such as liquid-ceph.

- `limes/internal/util/algorithms.go` -> `liquidapi/algorithms.go` without any changes
- `limes/internal/util/algorithms_test.go` -> `liquidapi/algorithms_test.go` with one small change (type `db.ProjectServiceID` is replaced by a local type)
- `limes/internal/liquids/utils.go` -> `liquidapi/utils.go` and `gophercloudext/utils.go` except for func PointerTo (which I hope to eliminate in Go 1.24)