### PR TITLE
add new package httptest

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ reusability. Feel free to add to this.
 * [gophercloudext](./gophercloudext) contains convenience functions for use with [Gophercloud](https://github.com/gophercloud/gophercloud). It is specifically intended as a lightweight replacement for `gophercloud/utils` with fewer dependencies.
 * [gopherpolicy](./gopherpolicy) integrates [Gophercloud](https://github.com/gophercloud/gophercloud) with [goslo.policy](https://github.com/databus23/goslo.policy), for OpenStack services that need to validate client tokens and check permissions.
 * [httpapi](./httpapi) contains opinionated base machinery for assembling and exposing an API consisting of HTTP endpoints.
-* [httpext](./httpext) adds some convenience functions to [net/http](https://golang.org/pkg/http/).
+* [httpext](./httpext) adds some convenience functions to [net/http](https://golang.org/pkg/net/http).
+* [httptest](./httptest) builds on [net/http/httptest](https://golang.org/pkg/net/http/httptest) to make process-local HTTP requests inside tests as smooth as possible.
 * [jobloop](./jobloop) contains the Job trait, which abstracts over reusable implementations of worker loops.
 * [liquidapi](./liquidapi) contains a server runtime and various other utilities for microservices implementing the [LIQUID API](https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid).
 * [logg](./logg) adds some convenience functions to [log](https://golang.org/pkg/log/).

--- a/assert/http.go
+++ b/assert/http.go
@@ -65,6 +65,25 @@ type HTTPRequest struct {
 // The HTTP response is returned, along with the response body. (resp.Body is
 // already exhausted when the function returns.) This is useful for tests that
 // want to do further checks on `resp` or want to use data from the response.
+//
+// Warning: This function does not work well in Ginkgo/Gomega because of how it logs output.
+// Please use httptest.Handler instead, which is much more suited to the Gomega style of assertions.
+// For example:
+//
+//	// instead of this...
+//	assert.HTTPRequest {
+//		Method:       "GET",
+//		Path:         "/v1/info",
+//		ExpectStatus: http.StatusOK,
+//		ExpectBody:   assert.JSONObject{"error_count": 0},
+//	}.Check(GinkgoT(), myHandler)
+//
+//	// ...do this
+//	h := httptest.NewHandler(myHandler)
+//	var info map[string]any
+//	resp := h.RespondTo(ctx, "GET /v1/info", httptest.ReceiveJSONInto(&info))
+//	Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+//	Expect(info).To(Equal(map[string]any{"error_count": 0}))
 func (r HTTPRequest) Check(t *testing.T, handler http.Handler) (resp *http.Response, responseBody []byte) {
 	t.Helper()
 

--- a/httptest/handler.go
+++ b/httptest/handler.go
@@ -1,0 +1,204 @@
+/*******************************************************************************
+*
+* Copyright 2025 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+// Package httptest builds on net/http/httptest to make process-local HTTP requests inside tests as smooth as possible.
+package httptest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+
+	"github.com/sapcc/go-bits/must"
+)
+
+// Handler is a wrapper around http.Handler providing convenience methods for use in tests.
+type Handler struct {
+	inner http.Handler
+}
+
+// NewHandler wraps the given http.Handler in type Handler to provide extra convenience methods.
+func NewHandler(inner http.Handler) Handler {
+	return Handler{inner}
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.inner.ServeHTTP(w, r)
+}
+
+// RespondTo executes an HTTP request against this handler.
+// The interface is optimized towards readability and brevity in tests for REST APIs:
+//
+//   - The request method and URL are given in a single string, e.g. "POST /v1/objects/new".
+//   - Additional headers, a request body, etc. can be provided as a list of options.
+//
+// The interface is optimized towards users of Ginkgo/Gomega.
+// When you get the response, always check it with HaveHTTPStatus() first.
+// This will catch any protocol-level and marshaling errors that may occur during the request.
+//
+//	var assets []Asset
+//	resp := h.RespondTo(ctx, "GET /v1/assets", httptest.ReceiveJSONInto(&assets))
+//	Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+//	Expect(assets).To(HaveLen(4))
+//	Expect(assets[2]).To(Equal("example"))
+func (h Handler) RespondTo(ctx context.Context, methodAndPath string, options ...RequestOption) *http.Response {
+	// NOTE: This function does not have an error return,
+	//       in order to avoid an extra `Expect(err).To(BeNil())` line at every callsite.
+	//
+	//       We expect users to do `Expect(resp).To(HaveHTTPStatus(some2xxStatus))`,
+	//       which will print the entire response including the error in the body.
+	//
+	//       There are also some cases in which this function panics.
+	//       This is reserved for situations where the test code is clearly written incorrectly.
+	//       Marshaling errors could come from a legitimate problem in the business logic, so they do not panic.
+	makeErrorResponse := func(reason string, err error) *http.Response {
+		return &http.Response{
+			Status:     "999 " + reason,
+			StatusCode: 999,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(err.Error())),
+		}
+	}
+
+	// parse methodAndPath
+	method, path, ok := strings.Cut(methodAndPath, " ")
+	if !ok {
+		panic(fmt.Sprintf("no method declared in methodAndPath = %q", methodAndPath))
+	}
+
+	// collect options
+	params := requestParams{
+		Headers: make(http.Header),
+	}
+	for _, opt := range options {
+		opt(&params)
+	}
+
+	// prepare request body, if any
+	reqBody := params.Body
+	if params.JSONBody != nil {
+		if reqBody != nil {
+			panic("cannot use both WithBody() and WithJSONBody() in the same request")
+		}
+		buf, err := json.Marshal(params.JSONBody)
+		if err != nil {
+			return makeErrorResponse("JSON Marshal Error", err)
+		}
+		reqBody = bytes.NewReader(buf)
+	}
+
+	// build request
+	req := must.Return(http.NewRequestWithContext(ctx, method, path, reqBody))
+	maps.Insert(req.Header, maps.All(params.Headers))
+
+	// obtain response
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	resp := rec.Result()
+
+	// parse response body (if requested)
+	if params.JSONTarget != nil && (resp.StatusCode >= 200 && resp.StatusCode <= 299) {
+		err := json.NewDecoder(resp.Body).Decode(params.JSONTarget)
+		if err == nil {
+			err = resp.Body.Close()
+			resp.Body = io.NopCloser(bytes.NewReader(nil))
+		}
+		if err != nil {
+			return makeErrorResponse("JSON Unmarshal Error", err)
+		}
+	}
+
+	return resp
+}
+
+// RequestOption controls optional behavior in func Handler.RespondTo().
+type RequestOption func(*requestParams)
+
+type requestParams struct {
+	Headers    http.Header
+	Body       io.Reader
+	JSONBody   any
+	JSONTarget any
+}
+
+// WithBody adds a request body to an HTTP request.
+//
+// If the caller does not specify a Content-Type using WithBody(), application/octet-stream will be set.
+func WithBody(r io.Reader) RequestOption {
+	return func(params *requestParams) {
+		params.Body = r
+		if params.Headers.Get("Content-Type") == "" {
+			params.Headers.Set("Content-Type", "application/octet-stream")
+		}
+	}
+}
+
+// WithHeader adds a single HTTP header to an HTTP request.
+func WithHeader(key, value string) RequestOption {
+	return func(params *requestParams) {
+		params.Headers.Set(key, value)
+	}
+}
+
+// WithHeaders adds several HTTP headers to an HTTP request.
+func WithHeaders(hdr http.Header) RequestOption {
+	return func(params *requestParams) {
+		maps.Insert(params.Headers, maps.All(hdr))
+	}
+}
+
+// WithJSONBody adds a JSON request body to an HTTP request.
+// The provided payload will be serialized into JSON.
+//
+// If the caller does not specify a Content-Type using WithBody(), application/json will be set.
+func WithJSONBody(payload any) RequestOption {
+	return func(params *requestParams) {
+		params.JSONBody = payload
+		if params.Headers.Get("Content-Type") == "" {
+			params.Headers.Set("Content-Type", "application/json; charset=utf-8")
+		}
+	}
+}
+
+// ReceiveJSONInto adds parsing of a JSON response body to an HTTP request.
+// If the response has a 2xx status code, its response body will be unmarshaled into the provided target.
+// If unmarshaling fails, the response will have status code 999 and contain the error message as a response body.
+func ReceiveJSONInto(target any) RequestOption {
+	// clear target, if any
+	//
+	// This is intended for when subsequent tests reuse the same target variable,
+	// to avoid data from a previous unmarshaling to leak into the next round.
+	v := reflect.ValueOf(target)
+	if v.Kind() != reflect.Pointer {
+		panic("argument for ReceiveJSONInto() must be a pointer")
+	}
+	reflect.Indirect(v).SetZero()
+
+	return func(params *requestParams) {
+		params.JSONTarget = target
+	}
+}

--- a/httptest/handler_test.go
+++ b/httptest/handler_test.go
@@ -1,0 +1,158 @@
+/*******************************************************************************
+*
+* Copyright 2025 SAP SE
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You should have received a copy of the License along with this
+* program. If not, you may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+
+package httptest_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sapcc/go-bits/assert"
+	"github.com/sapcc/go-bits/httptest"
+	"github.com/sapcc/go-bits/must"
+)
+
+// This example handler recognizes the endpoint "POST /reflect",
+// which returns all request headers as response headers with the extra prefix "Reflected-"
+// (e.g. "Reflected-Content-Type: text/plain").
+// Also, if there is a request body, it will be copied into the response body.
+var exampleHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost && r.URL.Path != "/reflect" {
+		http.NotFound(w, r)
+		return
+	}
+
+	for k, v := range r.Header {
+		w.Header()["Reflected-"+k] = v
+	}
+	w.WriteHeader(http.StatusOK)
+
+	if r.Body != nil {
+		_, err := io.Copy(w, r.Body)
+		if err != nil {
+			panic(err.Error())
+		}
+	}
+})
+
+func TestRespondTo(t *testing.T) {
+	h := httptest.NewHandler(exampleHandler)
+	ctx := context.TODO() // TODO: use t.Context() in Go 1.24+
+
+	// most basic invocation
+	resp := h.RespondTo(ctx, "POST /reflect")
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+
+	// check WithHeader()
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithHeader("Foo", "bar"),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.DeepEqual(t, "Reflected-Foo", resp.Header["Reflected-Foo"], []string{"bar"})
+
+	// check WithHeaders()
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithHeaders(http.Header{
+			"Foo":     {"bar"},
+			"Numbers": {"23", "42"},
+		}),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.DeepEqual(t, "Reflected-Foo", resp.Header["Reflected-Foo"], []string{"bar"})
+	assert.DeepEqual(t, "Reflected-Numbers", resp.Header["Reflected-Numbers"], []string{"23", "42"})
+
+	// check WithBody()
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithBody(strings.NewReader("Hello world")),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.DeepEqual(t, "Reflected-Content-Type", resp.Header.Get("Reflected-Content-Type"), "application/octet-stream")
+	buf := must.Return(io.ReadAll(resp.Body))
+	assert.DeepEqual(t, "Reflected Body", string(buf), "Hello world")
+
+	// check that WithHeader("Content-Type") overrides the default of WithBody()
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithHeader("Content-Type", "text/plain"),
+		httptest.WithBody(strings.NewReader("Hello world")),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.DeepEqual(t, "Reflected-Content-Type", resp.Header.Get("Reflected-Content-Type"), "text/plain")
+	buf = must.Return(io.ReadAll(resp.Body))
+	assert.DeepEqual(t, "Reflected Body", string(buf), "Hello world")
+
+	// check WithJSONBody()
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithJSONBody([]bool{true, false, true}),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.DeepEqual(t, "Reflected-Content-Type", resp.Header.Get("Reflected-Content-Type"), "application/json; charset=utf-8")
+	buf = must.Return(io.ReadAll(resp.Body))
+	assert.DeepEqual(t, "Reflected Body", string(buf), `[true,false,true]`)
+
+	// check that WithHeader("Content-Type") overrides the default of WithJSONBody()
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithHeader("Content-Type", "application/x-just-bools+json"),
+		httptest.WithJSONBody([]bool{true, false, true}),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.DeepEqual(t, "Reflected-Content-Type", resp.Header.Get("Reflected-Content-Type"), "application/x-just-bools+json")
+	buf = must.Return(io.ReadAll(resp.Body))
+	assert.DeepEqual(t, "Reflected Body", string(buf), `[true,false,true]`)
+
+	// check ReceiveJSONInto()
+	var output map[string]any
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithBody(strings.NewReader(`{"foo":"foofoo"}`)),
+		httptest.ReceiveJSONInto(&output),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.DeepEqual(t, "Reflected Body", output, map[string]any{"foo": "foofoo"})
+
+	// check that ReceiveJSONInto() zeroes its target before unmarshaling
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithBody(strings.NewReader(`{"bar":"barbar"}`)),
+		httptest.ReceiveJSONInto(&output),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.DeepEqual(t, "Reflected Body", output, map[string]any{"bar": "barbar"}) // "foo" member from previous test was removed before unmarshaling
+
+	// check how JSON marshaling errors are reported
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithJSONBody(time.Now), // functions cannot be serialized as JSON
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 999)
+	assert.DeepEqual(t, "Status", resp.Status, "999 JSON Marshal Error")
+	buf = must.Return(io.ReadAll(resp.Body))
+	assert.DeepEqual(t, "Error Message In Body", string(buf), "json: unsupported type: func() time.Time")
+
+	// check how JSON unmarshaling errors are reported
+	var outputNumber int
+	resp = h.RespondTo(ctx, "POST /reflect",
+		httptest.WithBody(strings.NewReader(`"Hello"`)),
+		httptest.ReceiveJSONInto(&outputNumber),
+	)
+	assert.DeepEqual(t, "Status", resp.StatusCode, 999)
+	assert.DeepEqual(t, "Status", resp.Status, "999 JSON Unmarshal Error")
+	buf = must.Return(io.ReadAll(resp.Body))
+	assert.DeepEqual(t, "Error Message In Body", string(buf), "json: cannot unmarshal string into Go value of type int")
+}


### PR DESCRIPTION
This is intended as a replacement for type assert.HTTPRequest, which does not play well with Ginkgo/Gomega. The big problem is that it wants to log several lines with t.Errorf() and t.Logf(). But in Ginkgo, Errorf() is aliased to Fatalf(), so we will be missing important log lines after the first error.