### PR TITLE
easypg: force C locale on .testdb

### DIFF
--- a/easypg/testsetup.go
+++ b/easypg/testsetup.go
@@ -29,6 +29,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -88,6 +89,12 @@ func WithTestDB(m *testing.M, action func() int) int {
 			"-c", "external_pid_file="+filepath.Join(rootPath, ".testdb/run/pid"),
 			"-c", "unix_socket_directories="+filepath.Join(rootPath, ".testdb/run"),
 			"-c", fmt.Sprintf("port=%d", testDBPort),
+		)
+		cmd.Env = append(slices.Clone(os.Environ()),
+			// We need to convince the DB to run with a C locale because we do regex matching on error messages
+			// for the "create database if missing" part of Connect().
+			"LC_ALL=C",
+			"LC_MESSAGES=C",
 		)
 		cmd.Stdin = nil
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
@wagnerd3 ran into problems with `make check` because our "create database if missing" logic does regex matching on the error messages, but he had German instead of English error messages because of his locale:
```
2025-02-04 14:35:58.867 CET [2761] FATAL:  Datenbank »testforbidclusteridheader« existiert nicht
```

For him, setting `LC_ALL=C` during initdb fixed the issue. I also added `LC_MESSAGES=C` here for good measure because locale settings are notoriously messy and varied across different users.