### PR TITLE
DistributeFairly: generate a testcase when crashing because of overflow

### DIFF
--- a/liquidapi/algorithms.go
+++ b/liquidapi/algorithms.go
@@ -84,6 +84,12 @@ func DistributeFairly[K comparable](total uint64, requested map[K]uint64) map[K]
 			return 0
 		}
 	})
+	if missing > uint64(len(keys)) {
+		// the algorithm ought to guarantee that the number of `missing`
+		// allocations is smaller than the number of keys, but we had this fail in the past,
+		// so this crash message is here to generate test cases as necessary
+		logg.Fatal("too many missing allocations in DistributeFairly for input: total = %d, requested = %#v", total, requested)
+	}
 	for _, key := range keys[len(keys)-int(missing):] { //nolint:gosec // algorithm ensures that no overflow happens on uint64 -> int cast
 		fair[key] += 1
 	}


### PR DESCRIPTION
This case is currently crashing in QA because the slice access in the loop below is bounds-checked, but I want to have it crash with a message that generates a useful testcase.