### PR TITLE
liquidapi: fix overflow in DistributeFairly

### DIFF
--- a/liquidapi/algorithms.go
+++ b/liquidapi/algorithms.go
@@ -36,18 +36,18 @@ import (
 // <https://en.wikipedia.org/wiki/Largest_remainder_method>.
 func DistributeFairly[K comparable](total uint64, requested map[K]uint64) map[K]uint64 {
 	// easy case: all requests can be granted
-	sumOfRequests := uint64(0)
+	sumOfRequests := 0.0
 	for _, request := range requested {
-		sumOfRequests += request
+		sumOfRequests += float64(request)
 	}
-	if sumOfRequests <= total {
+	if sumOfRequests <= float64(total) {
 		return requested
 	}
 
 	// a completely fair distribution would require using these floating-point values...
 	exact := make(map[K]float64, len(requested))
 	for key, request := range requested {
-		exact[key] = float64(total) * float64(request) / float64(sumOfRequests)
+		exact[key] = float64(total) * float64(request) / sumOfRequests
 	}
 
 	// ...but we have to round to uint64

--- a/liquidapi/algorithms_test.go
+++ b/liquidapi/algorithms_test.go
@@ -47,6 +47,20 @@ func TestDistributeFairlyWithLargeNumbers(t *testing.T) {
 		403: total / 4,
 		404: total / 4,
 	})
+
+	// Even after having made the above testcases green, this one occurred in the wild.
+	total = uint64(60)
+	requested = map[uint16]uint64{
+		401: 0x8000000000000000,
+		402: 0x8000000000000000,
+		403: 0x8000000000000000,
+	}
+	result = DistributeFairly(total, requested)
+	assert.DeepEqual(t, "output of DistributeFairly", result, map[uint16]uint64{
+		401: total / 3,
+		402: total / 3,
+		403: total / 3,
+	})
 }
 
 func TestDistributeDemandFairlyWithJustBalance(t *testing.T) {


### PR DESCRIPTION
When given very large numbers, `sumOfRequests` would overflow when calculated as a uint64, and therefore `fair` was also computed incorrectly.