### PR TITLE
regexpext: change ConfigSet API to use Option[] instead of default values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.16.0
 	github.com/lib/pq v1.10.9
+	github.com/majewsky/gg v1.0.0
 	github.com/prometheus/client_golang v1.21.1
 	github.com/prometheus/common v0.63.0
 	github.com/rabbitmq/amqp091-go v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/majewsky/gg v1.0.0 h1:d7ov8LJvsaNV/MpLkW5+xINap9JFxEs/GUJFUDNAPQk=
+github.com/majewsky/gg v1.0.0/go.mod h1:KC7qUlln1VBY90OE0jXMNjXW2b9B4jJ1heYQ08OzeAg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=

--- a/regexpext/configset_test.go
+++ b/regexpext/configset_test.go
@@ -22,6 +22,8 @@ package regexpext
 import (
 	"testing"
 
+	. "github.com/majewsky/gg/option"
+
 	"github.com/sapcc/go-bits/assert"
 )
 
@@ -31,9 +33,9 @@ func TestConfigSetPickWithLiterals(t *testing.T) {
 		{Key: "bar", Value: 23},
 	}
 
-	assert.DeepEqual(t, `cs.Pick("foo")`, cs.Pick("foo", 5), 42)
-	assert.DeepEqual(t, `cs.Pick("bar")`, cs.Pick("bar", 5), 23)
-	assert.DeepEqual(t, `cs.Pick("qux")`, cs.Pick("qux", 5), 5)
+	assert.DeepEqual(t, `cs.Pick("foo")`, cs.Pick("foo"), Some(42))
+	assert.DeepEqual(t, `cs.Pick("bar")`, cs.Pick("bar"), Some(23))
+	assert.DeepEqual(t, `cs.Pick("qux")`, cs.Pick("qux"), None[int]())
 }
 
 func TestConfigSetPickWithRegex(t *testing.T) {
@@ -42,10 +44,10 @@ func TestConfigSetPickWithRegex(t *testing.T) {
 		{Key: "bar", Value: 23},
 	}
 
-	assert.DeepEqual(t, `cs.Pick("foo")`, cs.Pick("foo", 5), 42)
-	assert.DeepEqual(t, `cs.Pick("bar")`, cs.Pick("bar", 5), 42) // first match wins!
-	assert.DeepEqual(t, `cs.Pick("qux")`, cs.Pick("qux", 5), 5)
-	assert.DeepEqual(t, `cs.Pick("foooo")`, cs.Pick("foooo", 5), 5) // regex matches full string only
+	assert.DeepEqual(t, `cs.Pick("foo")`, cs.Pick("foo"), Some(42))
+	assert.DeepEqual(t, `cs.Pick("bar")`, cs.Pick("bar"), Some(42)) // first match wins!
+	assert.DeepEqual(t, `cs.Pick("qux")`, cs.Pick("qux"), None[int]())
+	assert.DeepEqual(t, `cs.Pick("foooo")`, cs.Pick("foooo"), None[int]()) // regex matches full string only
 }
 
 func TestConfigSetWithFill(t *testing.T) {
@@ -63,14 +65,14 @@ func TestConfigSetWithFill(t *testing.T) {
 		{Key: "Bob", Value: Name{FirstName: "Bob", LastName: "Mc$1"}},
 	}
 
-	value := cs.PickAndFill("Jane Doe", Name{}, fill)
-	assert.DeepEqual(t, `cs.PickAndFill("Jane Doe")`, value, Name{FirstName: "Jane", LastName: "Doe"})
+	value := cs.PickAndFill("Jane Doe", fill)
+	assert.DeepEqual(t, `cs.PickAndFill("Jane Doe")`, value, Some(Name{FirstName: "Jane", LastName: "Doe"}))
 
 	// expand from the same template again, but with different values (this tests that the template was not modified)
-	value = cs.PickAndFill("John Dorian", Name{}, fill)
-	assert.DeepEqual(t, `cs.PickAndFill("John Dorian")`, value, Name{FirstName: "John", LastName: "Dorian"})
+	value = cs.PickAndFill("John Dorian", fill)
+	assert.DeepEqual(t, `cs.PickAndFill("John Dorian")`, value, Some(Name{FirstName: "John", LastName: "Dorian"}))
 
 	// unknown capture groups expand to empty strings, same as regexp.ExpandString()
-	value = cs.PickAndFill("Bob", Name{}, fill)
-	assert.DeepEqual(t, `cs.PickAndFill("Bob")`, value, Name{FirstName: "Bob", LastName: "Mc"})
+	value = cs.PickAndFill("Bob", fill)
+	assert.DeepEqual(t, `cs.PickAndFill("Bob")`, value, Some(Name{FirstName: "Bob", LastName: "Mc"}))
 }


### PR DESCRIPTION
This is the way it should have been from the beginning, but the Option[] type was not viable yet when I added ConfigSet in 2024.

But since I never got around to actually using ConfigSet anywhere (and GitHub code search on org:sapcc also does not find any existing usage), I feel confident breaking compatibility here at the last possible moment.