### PR TITLE
easypg: fix duplicate keys in snapshot

### DIFF
--- a/easypg/snapshot.go
+++ b/easypg/snapshot.go
@@ -22,6 +22,7 @@ package easypg
 import (
 	"database/sql"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -78,7 +79,9 @@ func newDBSnapshot(t TestingT, db *sql.DB) dbSnapshot {
 			columnName string
 		)
 		failOnErr(t, rows.Scan(&tableName, &columnName))
-		keyColumnNames[tableName] = append(keyColumnNames[tableName], columnName)
+		if !slices.Contains(keyColumnNames[tableName], columnName) {
+			keyColumnNames[tableName] = append(keyColumnNames[tableName], columnName)
+		}
 	}
 	failOnErr(t, rows.Err())
 	failOnErr(t, rows.Close()) //nolint:sqlclosecheck


### PR DESCRIPTION
In Surveyor, we have a table where the primary key and a foreign key constraint both contain the same column (`subpath`). This leads to this value being duplicated in easypg.Tracker snapshots, for example:

```
DELETE FROM ocm_component_commit_refs WHERE cversion_id = 1 AND repo_id = 1 AND commit_id = NULL AND commit_ref = '1111' AND subpath = '' AND subpath = '';
```