### PR TITLE
jobloop: fix missing error context on single-threaded jobs

### DIFF
--- a/jobloop/options.go
+++ b/jobloop/options.go
@@ -19,8 +19,12 @@ import (
 type Option func(*jobConfig)
 
 type jobConfig struct {
-	NumGoroutines   uint32
+	// controlled by user through the NumGoroutines() option
+	NumGoroutines uint32
+	// controlled by user through the WithLabel() option
 	PrefilledLabels prometheus.Labels
+	// only set internally within this library
+	WantsExtraErrorContext bool
 }
 
 func newJobConfig(opts []Option) jobConfig {

--- a/jobloop/producer_consumer.go
+++ b/jobloop/producer_consumer.go
@@ -91,11 +91,11 @@ type producerConsumerJobImpl[T any] struct {
 
 // Core producer-side behavior. This is used by ProcessOne in unit tests, as
 // well as by runSingleThreaded and runMultiThreaded in production.
-func (j *ProducerConsumerJob[T]) produceOne(ctx context.Context, cfg jobConfig, annotateErrors bool) (T, prometheus.Labels, error) {
+func (j *ProducerConsumerJob[T]) produceOne(ctx context.Context, cfg jobConfig) (T, prometheus.Labels, error) {
 	labels := j.Metadata.makeLabels(cfg)
 	task, err := j.DiscoverTask(ctx, labels)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		if annotateErrors {
+		if cfg.WantsExtraErrorContext {
 			err = fmt.Errorf("could not select task%s for job %q: %w",
 				cfg.PrefilledLabelsAsString(), j.Metadata.ReadableName, err)
 		}
@@ -106,9 +106,9 @@ func (j *ProducerConsumerJob[T]) produceOne(ctx context.Context, cfg jobConfig, 
 
 // Core consumer-side behavior. This is used by ProcessOne in unit tests, as
 // well as by runSingleThreaded and runMultiThreaded in production.
-func (j *ProducerConsumerJob[T]) consumeOne(ctx context.Context, cfg jobConfig, task T, labels prometheus.Labels, annotateErrors bool) error {
+func (j *ProducerConsumerJob[T]) consumeOne(ctx context.Context, cfg jobConfig, task T, labels prometheus.Labels) error {
 	err := j.ProcessTask(ctx, task, labels)
-	if err != nil && annotateErrors {
+	if err != nil && cfg.WantsExtraErrorContext {
 		err = fmt.Errorf("could not process task%s for job %q: %w",
 			cfg.PrefilledLabelsAsString(), j.Metadata.ReadableName, err)
 	}
@@ -120,21 +120,27 @@ func (j *ProducerConsumerJob[T]) consumeOne(ctx context.Context, cfg jobConfig, 
 func (i producerConsumerJobImpl[T]) processOne(ctx context.Context, cfg jobConfig) error {
 	j := i.j
 
-	task, labels, err := j.produceOne(ctx, cfg, false)
+	task, labels, err := j.produceOne(ctx, cfg)
 	if err != nil {
 		return err
 	}
-	return j.consumeOne(ctx, cfg, task, labels, false)
+	return j.consumeOne(ctx, cfg, task, labels)
 }
 
 // ProcessOne implements the jobloop.Job interface.
 func (i producerConsumerJobImpl[T]) ProcessOne(ctx context.Context, opts ...Option) error {
-	return i.processOne(ctx, newJobConfig(opts))
+	cfg := newJobConfig(opts)
+	// ProcessOne() is usually called during tests, so adding extra context to error messages is not helpful
+	// (it would only make error message matches more convoluted)
+	cfg.WantsExtraErrorContext = false
+
+	return i.processOne(ctx, cfg)
 }
 
 // Run implements the jobloop.Job interface.
 func (i producerConsumerJobImpl[T]) Run(ctx context.Context, opts ...Option) {
 	cfg := newJobConfig(opts)
+	cfg.WantsExtraErrorContext = true
 
 	switch cfg.NumGoroutines {
 	case 0:
@@ -173,7 +179,7 @@ func (i producerConsumerJobImpl[T]) runMultiThreaded(ctx context.Context, cfg jo
 	go func(ch chan<- taskWithLabels[T]) {
 		defer wg.Done()
 		for ctx.Err() == nil { // while ctx has not expired
-			task, labels, err := j.produceOne(ctx, cfg, true)
+			task, labels, err := j.produceOne(ctx, cfg)
 			if err == nil {
 				ch <- taskWithLabels[T]{task, labels}
 			} else {
@@ -194,7 +200,7 @@ func (i producerConsumerJobImpl[T]) runMultiThreaded(ctx context.Context, cfg jo
 		go func(ch <-chan taskWithLabels[T]) {
 			defer wg.Done()
 			for item := range ch {
-				err := j.consumeOne(ctx, cfg, item.Task, item.Labels, true)
+				err := j.consumeOne(ctx, cfg, item.Task, item.Labels)
 				if err != nil {
 					logg.Error(err.Error())
 				}


### PR DESCRIPTION
The implementation already had an affordance for adding extra error context in certain situations, but on ProducerConsumerJob, it was implemented incorrectly. The intent was to produce the longer error message at runtime, when writing error messages to the log file, and keep the shorter error message during tests. But because the single-threaded job loop uses the same code path as the test interface ProcessOne(), we ended up using the
short error format there as well.

This includes two small refactorings:

- Because fixing this with the existing pattern would have added an additional bool argument to more functions, which almost always reads badly in callsites, I went with a new field in type jobConfig instead.
- I also moved the fmt.Sprintf part of the error enrichment into a separate helper function to reduce code duplication. This will become relevant in the future when more context is added here.