### PR TITLE
soft-deprecate assert.HTTPRequest, add new assertions to package httptest

### DIFF
--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -23,6 +23,7 @@ reuse:
   annotations:
     - paths:
       - httpapi/fixtures/metrics.prom
+      - httptest/fixtures/example.txt
       - tools/release-info/go.mod
       SPDX-FileCopyrightText: SAP SE or an SAP affiliate company
       SPDX-License-Identifier: Apache-2.0

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -22,6 +22,7 @@ SPDX-License-Identifier = "Apache-2.0"
 [[annotations]]
 path = [
   "httpapi/fixtures/metrics.prom",
+  "httptest/fixtures/example.txt",
   "tools/release-info/go.mod",
 ]
 SPDX-FileCopyrightText = "SAP SE or an SAP affiliate company"

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -13,6 +13,15 @@ import (
 	"github.com/sapcc/go-bits/osext"
 )
 
+// Equal checks if the actual and expected value are equal according to == rules, and t.Errors() otherwise.
+func Equal[V comparable](t *testing.T, actual, expected V) bool {
+	if actual == expected {
+		return true
+	}
+	t.Errorf("expected %#v, but got %#v", expected, actual)
+	return false
+}
+
 // DeepEqual checks if the actual and expected value are equal as
 // determined by reflect.DeepEqual(), and t.Error()s otherwise.
 func DeepEqual[V any](t *testing.T, variable string, actual, expected V) bool {

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Equal checks if the actual and expected value are equal according to == rules, and t.Errors() otherwise.
-func Equal[V comparable](t *testing.T, actual, expected V) bool {
+func Equal[V comparable](t TestingT, actual, expected V) bool {
 	if actual == expected {
 		return true
 	}
@@ -48,4 +48,11 @@ func DeepEqual[V any](t *testing.T, variable string, actual, expected V) bool {
 	}
 
 	return false
+}
+
+// TestingT is an interface implemented by the *testing.T type.
+// Some tests inside go-bits use this interface to substitute a mock for the real *testing.T type.
+type TestingT interface {
+	Helper()
+	Errorf(msg string, args ...any)
 }

--- a/assert/http.go
+++ b/assert/http.go
@@ -50,11 +50,10 @@ type HTTPRequest struct {
 // already exhausted when the function returns.) This is useful for tests that
 // want to do further checks on `resp` or want to use data from the response.
 //
-// Warning: This function does not work well in Ginkgo/Gomega because of how it logs output.
-// Please use httptest.Handler instead, which is much more suited to the Gomega style of assertions.
-// For example:
+// Warning: This function is considered deprecated.
+// Please use httptest.Handler instead, which provides more flexible assertions.
+// For example, instead of this:
 //
-//	// instead of this...
 //	assert.HTTPRequest {
 //		Method:       "GET",
 //		Path:         "/v1/info",
@@ -62,7 +61,14 @@ type HTTPRequest struct {
 //		ExpectBody:   assert.JSONObject{"error_count": 0},
 //	}.Check(GinkgoT(), myHandler)
 //
-//	// ...do this
+// Do this when using the regular std test runner:
+//
+//	h := httptest.NewHandler(myHandler)
+//	resp := h.RespondTo(ctx, "GET /v1/info")
+//	resp.ExpectJSON(t, http.StatusOK, jsonmatch.Object{"error_count": 0})
+//
+// Or do this when using Ginkgo/Gomega:
+//
 //	h := httptest.NewHandler(myHandler)
 //	var info map[string]any
 //	resp := h.RespondTo(ctx, "GET /v1/info", httptest.ReceiveJSONInto(&info))

--- a/easypg/url_test.go
+++ b/easypg/url_test.go
@@ -28,7 +28,7 @@ func TestURLFrom(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	expected := "postgres://foouser:foopass@localhost:5432/foodb?application_name=go-bits%40testhostname&sslmode=disable"
-	assert.DeepEqual(t, "URLFrom result with everything included", url.String(), expected)
+	assert.Equal(t, url.String(), expected)
 
 	// check a URL with optional parts omitted
 	url, err = URLFrom(URLParts{
@@ -40,5 +40,5 @@ func TestURLFrom(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	expected = "postgres://foouser@localhost/foodb?application_name=go-bits%40testhostname"
-	assert.DeepEqual(t, "URLFrom result with optional parts omitted", url.String(), expected)
+	assert.Equal(t, url.String(), expected)
 }

--- a/errext/errext_test.go
+++ b/errext/errext_test.go
@@ -15,37 +15,37 @@ func TestAsAndIs(t *testing.T) {
 
 	// unwrapped error can be type-casted
 	ferr, ok := As[fooError](err1)
-	assert.DeepEqual(t, "As", ferr.Data, 23)
-	assert.DeepEqual(t, "As", ok, true)
+	assert.Equal(t, ferr.Data, 23)
+	assert.Equal(t, ok, true)
 	ok = IsOfType[fooError](err1)
-	assert.DeepEqual(t, "As", ok, true)
+	assert.Equal(t, ok, true)
 
 	// unwrapped error cannot be type-casted into incompatible type
 	_, ok = As[barError](err1) //nolint:errcheck
-	assert.DeepEqual(t, "As", ok, false)
+	assert.Equal(t, ok, false)
 	ok = IsOfType[barError](err1)
-	assert.DeepEqual(t, "As", ok, false)
+	assert.Equal(t, ok, false)
 
 	err2 := fmt.Errorf("operation failed: %w", err1)
 
 	// wrapped error can be type-casted
 	ferr, ok = As[fooError](err2)
-	assert.DeepEqual(t, "As", ferr.Data, 23)
-	assert.DeepEqual(t, "As", ok, true)
+	assert.Equal(t, ferr.Data, 23)
+	assert.Equal(t, ok, true)
 	ok = IsOfType[fooError](err1)
-	assert.DeepEqual(t, "As", ok, true)
+	assert.Equal(t, ok, true)
 
 	// wrapped error cannot be type-casted into incompatible type
 	_, ok = As[barError](err2) //nolint:errcheck
-	assert.DeepEqual(t, "As", ok, false)
+	assert.Equal(t, ok, false)
 	ok = IsOfType[barError](err1)
-	assert.DeepEqual(t, "As", ok, false)
+	assert.Equal(t, ok, false)
 
 	// nil error cannot be type-casted at all
 	_, ok = As[fooError](nil) //nolint:errcheck
-	assert.DeepEqual(t, "As", ok, false)
+	assert.Equal(t, ok, false)
 	ok = IsOfType[fooError](nil)
-	assert.DeepEqual(t, "As", ok, false)
+	assert.Equal(t, ok, false)
 }
 
 type fooError struct{ Data int }

--- a/httptest/fixtures/example.txt
+++ b/httptest/fixtures/example.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/httptest/handler_test.go
+++ b/httptest/handler_test.go
@@ -44,13 +44,13 @@ func TestRespondTo(t *testing.T) {
 
 	// most basic invocation
 	resp := h.RespondTo(ctx, "POST /reflect")
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.Equal(t, resp.StatusCode, 200)
 
 	// check WithHeader()
 	resp = h.RespondTo(ctx, "POST /reflect",
 		httptest.WithHeader("Foo", "bar"),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.Equal(t, resp.StatusCode, 200)
 	assert.DeepEqual(t, "Reflected-Foo", resp.Header["Reflected-Foo"], []string{"bar"})
 
 	// check WithHeaders()
@@ -60,7 +60,7 @@ func TestRespondTo(t *testing.T) {
 			"Numbers": {"23", "42"},
 		}),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.Equal(t, resp.StatusCode, 200)
 	assert.DeepEqual(t, "Reflected-Foo", resp.Header["Reflected-Foo"], []string{"bar"})
 	assert.DeepEqual(t, "Reflected-Numbers", resp.Header["Reflected-Numbers"], []string{"23", "42"})
 
@@ -68,39 +68,39 @@ func TestRespondTo(t *testing.T) {
 	resp = h.RespondTo(ctx, "POST /reflect",
 		httptest.WithBody(strings.NewReader("Hello world")),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
-	assert.DeepEqual(t, "Reflected-Content-Type", resp.Header.Get("Reflected-Content-Type"), "application/octet-stream")
+	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, resp.Header.Get("Reflected-Content-Type"), "application/octet-stream")
 	buf := must.Return(io.ReadAll(resp.Body))
-	assert.DeepEqual(t, "Reflected Body", string(buf), "Hello world")
+	assert.Equal(t, string(buf), "Hello world")
 
 	// check that WithHeader("Content-Type") overrides the default of WithBody()
 	resp = h.RespondTo(ctx, "POST /reflect",
 		httptest.WithHeader("Content-Type", "text/plain"),
 		httptest.WithBody(strings.NewReader("Hello world")),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
-	assert.DeepEqual(t, "Reflected-Content-Type", resp.Header.Get("Reflected-Content-Type"), "text/plain")
+	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, resp.Header.Get("Reflected-Content-Type"), "text/plain")
 	buf = must.Return(io.ReadAll(resp.Body))
-	assert.DeepEqual(t, "Reflected Body", string(buf), "Hello world")
+	assert.Equal(t, string(buf), "Hello world")
 
 	// check WithJSONBody()
 	resp = h.RespondTo(ctx, "POST /reflect",
 		httptest.WithJSONBody([]bool{true, false, true}),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
-	assert.DeepEqual(t, "Reflected-Content-Type", resp.Header.Get("Reflected-Content-Type"), "application/json; charset=utf-8")
+	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, resp.Header.Get("Reflected-Content-Type"), "application/json; charset=utf-8")
 	buf = must.Return(io.ReadAll(resp.Body))
-	assert.DeepEqual(t, "Reflected Body", string(buf), `[true,false,true]`)
+	assert.Equal(t, string(buf), `[true,false,true]`)
 
 	// check that WithHeader("Content-Type") overrides the default of WithJSONBody()
 	resp = h.RespondTo(ctx, "POST /reflect",
 		httptest.WithHeader("Content-Type", "application/x-just-bools+json"),
 		httptest.WithJSONBody([]bool{true, false, true}),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
-	assert.DeepEqual(t, "Reflected-Content-Type", resp.Header.Get("Reflected-Content-Type"), "application/x-just-bools+json")
+	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, resp.Header.Get("Reflected-Content-Type"), "application/x-just-bools+json")
 	buf = must.Return(io.ReadAll(resp.Body))
-	assert.DeepEqual(t, "Reflected Body", string(buf), `[true,false,true]`)
+	assert.Equal(t, string(buf), `[true,false,true]`)
 
 	// check ReceiveJSONInto()
 	var output map[string]any
@@ -108,7 +108,7 @@ func TestRespondTo(t *testing.T) {
 		httptest.WithBody(strings.NewReader(`{"foo":"foofoo"}`)),
 		httptest.ReceiveJSONInto(&output),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.Equal(t, resp.StatusCode, 200)
 	assert.DeepEqual(t, "Reflected Body", output, map[string]any{"foo": "foofoo"})
 
 	// check that ReceiveJSONInto() zeroes its target before unmarshaling
@@ -116,17 +116,17 @@ func TestRespondTo(t *testing.T) {
 		httptest.WithBody(strings.NewReader(`{"bar":"barbar"}`)),
 		httptest.ReceiveJSONInto(&output),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 200)
+	assert.Equal(t, resp.StatusCode, 200)
 	assert.DeepEqual(t, "Reflected Body", output, map[string]any{"bar": "barbar"}) // "foo" member from previous test was removed before unmarshaling
 
 	// check how JSON marshaling errors are reported
 	resp = h.RespondTo(ctx, "POST /reflect",
 		httptest.WithJSONBody(time.Now), // functions cannot be serialized as JSON
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 999)
-	assert.DeepEqual(t, "Status", resp.Status, "999 JSON Marshal Error")
+	assert.Equal(t, resp.StatusCode, 999)
+	assert.Equal(t, resp.Status, "999 JSON Marshal Error")
 	buf = must.Return(io.ReadAll(resp.Body))
-	assert.DeepEqual(t, "Error Message In Body", string(buf), "json: unsupported type: func() time.Time")
+	assert.Equal(t, string(buf), "json: unsupported type: func() time.Time")
 
 	// check how JSON unmarshaling errors are reported
 	var outputNumber int
@@ -134,8 +134,8 @@ func TestRespondTo(t *testing.T) {
 		httptest.WithBody(strings.NewReader(`"Hello"`)),
 		httptest.ReceiveJSONInto(&outputNumber),
 	)
-	assert.DeepEqual(t, "Status", resp.StatusCode, 999)
-	assert.DeepEqual(t, "Status", resp.Status, "999 JSON Unmarshal Error")
+	assert.Equal(t, resp.StatusCode, 999)
+	assert.Equal(t, resp.Status, "999 JSON Unmarshal Error")
 	buf = must.Return(io.ReadAll(resp.Body))
-	assert.DeepEqual(t, "Error Message In Body", string(buf), "json: cannot unmarshal string into Go value of type int")
+	assert.Equal(t, string(buf), "json: cannot unmarshal string into Go value of type int")
 }

--- a/mock/clock_test.go
+++ b/mock/clock_test.go
@@ -13,23 +13,23 @@ import (
 func TestClock(t *testing.T) {
 	// clock should start at zero
 	c := NewClock()
-	assert.DeepEqual(t, "Clock.Now as Unix timestamp", c.Now().Unix(), int64(0))
+	assert.Equal(t, c.Now().Unix(), int64(0))
 
 	// clock should not advance on its own
-	assert.DeepEqual(t, "Clock.Now as Unix timestamp", c.Now().Unix(), int64(0))
+	assert.Equal(t, c.Now().Unix(), int64(0))
 
 	// clock should advance when asked to
 	c.StepBy(5 * time.Minute)
-	assert.DeepEqual(t, "Clock.Now as Unix timestamp", c.Now().Unix(), int64(300))
+	assert.Equal(t, c.Now().Unix(), int64(300))
 
 	// adding a listener should invoke the callback immediately
 	currentTime := int64(-1)
 	c.AddListener(func(t time.Time) {
 		currentTime = t.Unix()
 	})
-	assert.DeepEqual(t, "Unix timestamp from callback", currentTime, int64(300))
+	assert.Equal(t, currentTime, int64(300))
 
 	// advancing the clock should invoke the callback
 	c.StepBy(time.Second)
-	assert.DeepEqual(t, "Unix timestamp from callback", currentTime, int64(301))
+	assert.Equal(t, currentTime, int64(301))
 }

--- a/osext/env_test.go
+++ b/osext/env_test.go
@@ -6,7 +6,6 @@
 package osext_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -23,52 +22,50 @@ func TestGetenv(t *testing.T) {
 	t.Setenv(KEY, VAL)
 
 	str, err := osext.NeedGetenv(KEY)
-	assert.DeepEqual(t, "result from NeedGetenv", str, VAL)
-	assert.DeepEqual(t, "error from NeedGetenv", err, nil)
+	assert.Equal(t, str, VAL)
+	assert.Equal(t, err, nil)
 
 	str = osext.GetenvOrDefault(KEY, DEFAULT)
-	assert.DeepEqual(t, "result from GetenvOrDefault", str, VAL)
+	assert.Equal(t, str, VAL)
 
 	ok := osext.GetenvBool(KEY)
-	assert.DeepEqual(t, "result from GetenvBool", ok, false) // not a valid boolean literal -> false
+	assert.Equal(t, ok, false) // not a valid boolean literal -> false
 
 	// test with empty value
 	t.Setenv(KEY, "")
 
 	_, err = osext.NeedGetenv(KEY)
-	assert.DeepEqual(t, "error from NeedGetenv", err, error(osext.MissingEnvError{Key: KEY}))
+	assert.Equal(t, err, error(osext.MissingEnvError{Key: KEY}))
 
 	str = osext.GetenvOrDefault(KEY, DEFAULT)
-	assert.DeepEqual(t, "result from GetenvOrDefault", str, DEFAULT)
+	assert.Equal(t, str, DEFAULT)
 
 	ok = osext.GetenvBool(KEY)
-	assert.DeepEqual(t, "result from GetenvBool", ok, false)
+	assert.Equal(t, ok, false)
 
 	// test with null value
 	os.Unsetenv(KEY)
 
 	_, err = osext.NeedGetenv(KEY)
-	assert.DeepEqual(t, "error from NeedGetenv", err, error(osext.MissingEnvError{Key: KEY}))
+	assert.Equal(t, err, error(osext.MissingEnvError{Key: KEY}))
 
 	str = osext.GetenvOrDefault(KEY, DEFAULT)
-	assert.DeepEqual(t, "result from GetenvOrDefault", str, DEFAULT)
+	assert.Equal(t, str, DEFAULT)
 
 	ok = osext.GetenvBool(KEY)
-	assert.DeepEqual(t, "result from GetenvBool", ok, false)
+	assert.Equal(t, ok, false)
 
 	// test GetenvBool with explicitly true-ish values
 	for _, value := range []string{"t", "True", "1"} {
+		t.Logf("testing GetenvBool for %q", value)
 		t.Setenv(KEY, value)
-		ok = osext.GetenvBool(KEY)
-		msg := fmt.Sprintf("result from GetenvBool for %q", value)
-		assert.DeepEqual(t, msg, ok, true)
+		assert.Equal(t, osext.GetenvBool(KEY), true)
 	}
 
 	// test GetenvBool with explicitly false-ish values
 	for _, value := range []string{"f", "False", "0"} {
+		t.Logf("testing GetenvBool for %q", value)
 		t.Setenv(KEY, value)
-		ok = osext.GetenvBool(KEY)
-		msg := fmt.Sprintf("result from GetenvBool for %q", value)
-		assert.DeepEqual(t, msg, ok, false)
+		assert.Equal(t, osext.GetenvBool(KEY), false)
 	}
 }

--- a/regexpext/configset_test.go
+++ b/regexpext/configset_test.go
@@ -17,9 +17,9 @@ func TestConfigSetPickWithLiterals(t *testing.T) {
 		{Key: "bar", Value: 23},
 	}
 
-	assert.DeepEqual(t, `cs.Pick("foo")`, cs.Pick("foo"), Some(42))
-	assert.DeepEqual(t, `cs.Pick("bar")`, cs.Pick("bar"), Some(23))
-	assert.DeepEqual(t, `cs.Pick("qux")`, cs.Pick("qux"), None[int]())
+	assert.Equal(t, cs.Pick("foo"), Some(42))
+	assert.Equal(t, cs.Pick("bar"), Some(23))
+	assert.Equal(t, cs.Pick("qux"), None[int]())
 }
 
 func TestConfigSetPickWithRegex(t *testing.T) {
@@ -28,10 +28,10 @@ func TestConfigSetPickWithRegex(t *testing.T) {
 		{Key: "bar", Value: 23},
 	}
 
-	assert.DeepEqual(t, `cs.Pick("foo")`, cs.Pick("foo"), Some(42))
-	assert.DeepEqual(t, `cs.Pick("bar")`, cs.Pick("bar"), Some(42)) // first match wins!
-	assert.DeepEqual(t, `cs.Pick("qux")`, cs.Pick("qux"), None[int]())
-	assert.DeepEqual(t, `cs.Pick("foooo")`, cs.Pick("foooo"), None[int]()) // regex matches full string only
+	assert.Equal(t, cs.Pick("foo"), Some(42))
+	assert.Equal(t, cs.Pick("bar"), Some(42)) // first match wins!
+	assert.Equal(t, cs.Pick("qux"), None[int]())
+	assert.Equal(t, cs.Pick("foooo"), None[int]()) // regex matches full string only
 }
 
 func TestConfigSetWithFill(t *testing.T) {
@@ -50,13 +50,13 @@ func TestConfigSetWithFill(t *testing.T) {
 	}
 
 	value := cs.PickAndFill("Jane Doe", fill)
-	assert.DeepEqual(t, `cs.PickAndFill("Jane Doe")`, value, Some(Name{FirstName: "Jane", LastName: "Doe"}))
+	assert.Equal(t, value, Some(Name{FirstName: "Jane", LastName: "Doe"}))
 
 	// expand from the same template again, but with different values (this tests that the template was not modified)
 	value = cs.PickAndFill("John Dorian", fill)
-	assert.DeepEqual(t, `cs.PickAndFill("John Dorian")`, value, Some(Name{FirstName: "John", LastName: "Dorian"}))
+	assert.Equal(t, value, Some(Name{FirstName: "John", LastName: "Dorian"}))
 
 	// unknown capture groups expand to empty strings, same as regexp.ExpandString()
 	value = cs.PickAndFill("Bob", fill)
-	assert.DeepEqual(t, `cs.PickAndFill("Bob")`, value, Some(Name{FirstName: "Bob", LastName: "Mc"}))
+	assert.Equal(t, value, Some(Name{FirstName: "Bob", LastName: "Mc"}))
 }

--- a/regexpext/regexpext_test.go
+++ b/regexpext/regexpext_test.go
@@ -71,31 +71,31 @@ func TestUnmarshalGood(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		assert.DeepEqual(t, "td.Text", td.Text, "hello")
+		assert.Equal(t, td.Text, "hello")
 
 		rx, err := td.Plain.Regexp()
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		assert.DeepEqual(t, "td.Plain", rx.String(), "hel*o")
+		assert.Equal(t, rx.String(), "hel*o")
 
 		rx, err = td.Bounded.Regexp()
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		assert.DeepEqual(t, "td.Bounded", rx.String(), "^(?:hey?llo)$")
+		assert.Equal(t, rx.String(), "^(?:hey?llo)$")
 
 		// test behavior of shortcut methods
-		assert.DeepEqual(t, "MatchString result", td.Plain.MatchString("hello"), true)
-		assert.DeepEqual(t, "MatchString result", td.Plain.MatchString("helko"), false)
-		assert.DeepEqual(t, "MatchString result", td.Plain.MatchString("--hello--"), true)
-		assert.DeepEqual(t, "MatchString result", td.Plain.MatchString("--hello"), true)
-		assert.DeepEqual(t, "MatchString result", td.Plain.MatchString("hello--"), true)
-		assert.DeepEqual(t, "MatchString result", td.Bounded.MatchString("hello"), true)
-		assert.DeepEqual(t, "MatchString result", td.Bounded.MatchString("helko"), false)
-		assert.DeepEqual(t, "MatchString result", td.Bounded.MatchString("--hello--"), false)
-		assert.DeepEqual(t, "MatchString result", td.Bounded.MatchString("--hello"), false)
-		assert.DeepEqual(t, "MatchString result", td.Bounded.MatchString("hello--"), false)
+		assert.Equal(t, td.Plain.MatchString("hello"), true)
+		assert.Equal(t, td.Plain.MatchString("helko"), false)
+		assert.Equal(t, td.Plain.MatchString("--hello--"), true)
+		assert.Equal(t, td.Plain.MatchString("--hello"), true)
+		assert.Equal(t, td.Plain.MatchString("hello--"), true)
+		assert.Equal(t, td.Bounded.MatchString("hello"), true)
+		assert.Equal(t, td.Bounded.MatchString("helko"), false)
+		assert.Equal(t, td.Bounded.MatchString("--hello--"), false)
+		assert.Equal(t, td.Bounded.MatchString("--hello"), false)
+		assert.Equal(t, td.Bounded.MatchString("hello--"), false)
 
 		assert.DeepEqual(t, "FindStringSubmatch result", td.Plain.FindStringSubmatch("hello"), []string{"hello"})
 		assert.DeepEqual(t, "FindStringSubmatch result", td.Plain.FindStringSubmatch("helko"), []string(nil))
@@ -115,7 +115,7 @@ func TestUnmarshalBad(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected Unmarshal() to fail, but succeeded")
 		}
-		assert.DeepEqual(t, "err.Error()", err.Error(), expectedError)
+		assert.Equal(t, err.Error(), expectedError)
 	}
 }
 
@@ -128,15 +128,15 @@ func TestUnmarshalEmpty(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		assert.DeepEqual(t, "td.Text", td.Text, "")
-		assert.DeepEqual(t, "td.Plain", td.Plain, PlainRegexp(""))
-		assert.DeepEqual(t, "td.Bounded", td.Bounded, BoundedRegexp(""))
+		assert.Equal(t, td.Text, "")
+		assert.Equal(t, td.Plain, PlainRegexp(""))
+		assert.Equal(t, td.Bounded, BoundedRegexp(""))
 
 		// test behavior of shortcut methods
-		assert.DeepEqual(t, "MatchString result", td.Plain.MatchString(""), true)
-		assert.DeepEqual(t, "MatchString result", td.Plain.MatchString("foo"), true)
-		assert.DeepEqual(t, "MatchString result", td.Bounded.MatchString(""), true)
-		assert.DeepEqual(t, "MatchString result", td.Bounded.MatchString("foo"), false)
+		assert.Equal(t, td.Plain.MatchString(""), true)
+		assert.Equal(t, td.Plain.MatchString("foo"), true)
+		assert.Equal(t, td.Bounded.MatchString(""), true)
+		assert.Equal(t, td.Bounded.MatchString("foo"), false)
 
 		assert.DeepEqual(t, "FindStringSubmatch result", td.Plain.FindStringSubmatch(""), []string{""})
 		assert.DeepEqual(t, "FindStringSubmatch result", td.Plain.FindStringSubmatch("foo"), []string{""})
@@ -159,7 +159,7 @@ func TestMarshalGood(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		assert.DeepEqual(t, "Marshal", string(buf), proto.Pick(testGood))
+		assert.Equal(t, string(buf), proto.Pick(testGood))
 	}
 }
 
@@ -177,7 +177,7 @@ func TestMarshalEmpty(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		assert.DeepEqual(t, "Marshal", string(buf), proto.Pick(testEmpty))
+		assert.Equal(t, string(buf), proto.Pick(testEmpty))
 	}
 }
 
@@ -194,7 +194,7 @@ func TestMarshalOmitEmpty(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		assert.DeepEqual(t, "Marshal", string(buf), proto.Pick(testOmitEmpty))
+		assert.Equal(t, string(buf), proto.Pick(testOmitEmpty))
 	}
 }
 
@@ -204,8 +204,9 @@ func TestIsLiteral(t *testing.T) {
 	// regexp.QuoteMeta() escapes them; isLiteral() must agree with this.
 	for codepoint := uint8(32); codepoint < 127; codepoint++ {
 		text := fmt.Sprintf("a%cb", rune(codepoint)) // e.g. "a b", "a*b", etc.
+		t.Logf("testing with %q", text)
+
 		expected := regexp.QuoteMeta(text) == text
-		actual := isLiteral(text)
-		assert.DeepEqual(t, fmt.Sprintf("verdict for %q", text), actual, expected)
+		assert.Equal(t, isLiteral(text), expected)
 	}
 }


### PR DESCRIPTION
As per usual, this branch consists of multiple commits, each limited to a specific changeset and accompanied by a meaningful commit message. I recommend reviewing those commits separately.

The assert.HTTPRequest type is one of the oldest APIs in go-bits, dating back over seven years. It has served us well, but it has always felt a bit clunky to me. Last year, when evaluating Ginkgo, I added package httptest as an alternative specifically for the part of making HTTP requests (but not for the part of asserting on responses, which in Ginkgo is covered by Gomega).

Now, it is well-known that I have come to dislike Ginkgo quite a bit. But I still want to use (and build on) the good parts of go-bits/httptest. This PR does just that. Since there are no active users of go-bits/httptest that I know of (besides openstack-blueprint which should be easy enough to convert; I want to get rid of Ginkgo there anyway), I took the liberty of breaking backwards-compatibility with the interface here. `httptest.Handler.RespondTo()` does not return a `*http.Response` anymore, but instead a custom Response type that brings several useful assertions and is built for allowing custom assertions to be constructed easily, e.g. by providing access to the response body directly, both as `[]byte` and `string`, without a detour through `io.ReadAll()`.

The basic usage pattern for httptest.Response is to assert on each attribute separately. For example:

```go
resp := h.RespondTo(ctx, "GET /v1/hello")
assert.Equal(t, resp.StatusCode(), http.StatusOK)
assert.Equal(t, resp.Header().Get("Content-Type"), "text/plain; charset=utf-8")
assert.Equal(t, resp.BodyString(), "Hello world!")
```

Since most tests will want to check status and body, a pair of assertions is provided that checks both status and body at the same time for the two most common formats: ExpectText for plain-text messages and ExpectJSON for JSON payloads (using the new gg/jsonmatch library that improves on `assert.JSONObject` by offering field captures):

```go
resp := h.RespondTo(ctx, "GET /v1/hello")
resp.ExpectText(t, http.StatusOK, "Hello world!")
assert.Equal(t, resp.Header().Get("Content-Type"), "text/plain; charset=utf-8")
```