### PR TITLE
assert, easypg, httptest: cleanup *.actual files if diff is empty

### DIFF
--- a/easypg/testhelpers.go
+++ b/easypg/testhelpers.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sapcc/go-bits/internal/testdiff"
 	"github.com/sapcc/go-bits/osext"
 )
 
@@ -83,19 +84,7 @@ type Assertable struct {
 // file. A test error is generated in case of differences.
 func (a Assertable) AssertEqualToFile(fixtureFile string) {
 	a.t.Helper()
-
-	// write actual content to file to make it easy to copy the computed result over
-	// to the fixture path when a new test is added or an existing one is modified
-	fixturePath, err := filepath.Abs(fixtureFile)
-	failOnErr(a.t, err)
-	actualPath := fixturePath + ".actual"
-	failOnErr(a.t, os.WriteFile(actualPath, []byte(a.payload), 0o666))
-
-	cmd := exec.Command("diff", "-u", fixturePath, actualPath)
-	cmd.Stdin = nil
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	failOnErr(a.t, cmd.Run())
+	failOnErr(a.t, testdiff.DiffAgainstFixtureFile(fixtureFile, []byte(a.payload)))
 }
 
 var whitespaceAtStartOfLineRx = regexp.MustCompile(`(?m)^\s+`)

--- a/internal/testdiff/diff.go
+++ b/internal/testdiff/diff.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package testdiff
+
+import (
+	"os"
+	"os/exec"
+)
+
+// DiffAgainstFixtureFile checks that the contents of the file at the given
+// path are equal to the provided bytestring. If not, the provided bytestring
+// will be stored at `path + ".actual"` to allow the user to inspect the diff.
+func DiffAgainstFixtureFile(path string, actual []byte) error {
+	// write actual content to file to make it easy to copy the computed result over
+	// to the fixture path when a new test is added or an existing one is modified
+	actualPath := path + ".actual"
+	err := os.WriteFile(actualPath, actual, 0o666)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// if there is no diff, we do not need to retain the ".actual" file;
+		// this is especially important because, if `reuse lint` runs later as part
+		// of the full test suite, it might be confused about the licensing of this
+		// irrelevant temporary file
+		if err == nil {
+			err = os.Remove(actualPath)
+		}
+	}()
+
+	cmd := exec.Command("diff", "-u", path, actualPath)
+	cmd.Stdin = nil
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
As explained in the code comment for the new internal helper function.