### PR TITLE
replace *testing.T with testing.TB in public APIs

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -110,7 +110,7 @@ func ErrEqual(t TestingT, actual error, expectedErrorOrMessageOrRegexp any) bool
 
 // DeepEqual checks if the actual and expected value are equal as
 // determined by reflect.DeepEqual(), and t.Error()s otherwise.
-func DeepEqual[V any](t *testing.T, variable string, actual, expected V) bool {
+func DeepEqual[V any](t testing.TB, variable string, actual, expected V) bool {
 	t.Helper()
 	if reflect.DeepEqual(actual, expected) {
 		return true

--- a/must/must.go
+++ b/must/must.go
@@ -32,7 +32,7 @@ func Succeed(err error) {
 
 // SucceedT is a variant of Succeed() for use in unit tests.
 // Instead of exiting the program, any non-nil errors are reported with t.Fatal().
-func SucceedT(t *testing.T, err error) {
+func SucceedT(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatal(err.Error())
@@ -61,7 +61,7 @@ func Return[V any](val V, err error) V {
 // For example:
 //
 //	buf := must.ReturnT(os.ReadFile("config.ini"))(t)
-func ReturnT[V any](val V, err error) func(*testing.T) V {
+func ReturnT[V any](val V, err error) func(testing.TB) V {
 	// NOTE: This is the only function signature that works. We cannot do something like
 	//
 	//	myMust := must.WithT(t)
@@ -74,7 +74,7 @@ func ReturnT[V any](val V, err error) func(*testing.T) V {
 	//
 	// because filling multiple arguments using a call expression with multiple return values
 	// is only allowed when there are no other arguments.
-	return func(t *testing.T) V {
+	return func(t testing.TB) V {
 		t.Helper()
 		SucceedT(t, err)
 		return val


### PR DESCRIPTION
This allows affected functions to be called within benchmark tests. `testing.T` and `testing.B` share most of their methods, which is expressed by the `testing.TB` interface.

Ref: https://pkg.go.dev/testing#TB