### PR TITLE
httptest: add MergeRequestOptions and Response.Expect

### DIFF
--- a/httptest/handler.go
+++ b/httptest/handler.go
@@ -164,6 +164,34 @@ func WithJSONBody(payload any) RequestOption {
 	}
 }
 
+// MergeRequestOptions fuses multiple [RequestOption] instances into a single instance.
+// This is useful for constructing higher-level RequestOptions within an application's test suite, to avoid repetition.
+// For example:
+//
+//	// in the test support library
+//	type CustomAPIPayload struct {
+//		MediaType string
+//		Contents []byte
+//	}
+//	func WithAPIPayload(p APIPayload) httptest.RequestOption {
+//		return httptest.MergeRequestOptions(
+//			httptest.WithHeader("Content-Type", p.MediaType),
+//			httptest.WithHeader("Content-Range", fmt.Sprintf("bytes 0-%d", len(p.Contents))),
+//			httptest.WithBody(p.Contents),
+//		)
+//	}
+//
+//	// within the test function
+//	handler.RespondTo("PUT /payloads/1", WithAPIPayload(p)).
+//		ExpectStatus(t, http.StatusCreated)
+func MergeRequestOptions(options ...RequestOption) RequestOption {
+	return func(p *requestParams) {
+		for _, opt := range options {
+			opt(p)
+		}
+	}
+}
+
 // Response is the result type of Handler.RespondTo().
 // It provides all components of the generated HTTP response as plain data fields to assert against,
 // as well as convenience methods for complex assertions:
@@ -483,4 +511,41 @@ func (r Response) ExpectBodyAsInFixture(t assert.TestingT, statusCode int, fixtu
 	if err != nil {
 		t.Errorf("response body does not match with %s: %s", fixturePath, err.Error())
 	}
+}
+
+// Expect allows chaining a custom assertion into Response's chained method style.
+// The following are identical:
+//
+//	resp := h.RespondTo(ctx, "GET /foo/bar")
+//	assertion(resp)
+//	resp.ExpectStatus(t, http.StatusOK)
+//
+//	h.RespondTo(ctx, "GET /foo/bar").
+//		Expect(assertion).
+//		ExpectStatus(t, http.StatusOK)
+//
+// But the second one looks much nicer.
+// This facility is provided for higher-level assertions within an application's test suite, to avoid repetition.
+// For example:
+//
+//	// in the test support library
+//	type CustomAPIPayload struct {
+//		MediaType string
+//		Contents []byte
+//	}
+//	func ResponseContainingAPIPayload(t *testing.T, p APIPayload) func(Response) {
+//		return func(r Response) {
+//			r.ExpectHeaders(t, http.Header{
+//				"Content-Length": {strconv.Itoa(len(p.Contents))},
+//				"Content-Type":   {p.MediaType},
+//			}).ExpectBody(t, http.StatusOK, p.Contents)
+//		}
+//	}
+//
+//	// within the test function
+//	handler.RespondTo("GET /payloads/1").
+//		Expect(ResponseContainingAPIPayload(t, p))
+func (r Response) Expect(assertion func(Response)) Response {
+	assertion(r)
+	return r
 }

--- a/httptest/handler_test.go
+++ b/httptest/handler_test.go
@@ -86,6 +86,15 @@ func TestRespondTo(t *testing.T) {
 	assert.Equal(t, resp.Header().Get("Reflected-Content-Type"), "text/plain")
 	assert.Equal(t, resp.BodyString(), "Hello world")
 
+	// same check as the one above, but rephrased to provide test coverage for MergeRequestOptions()
+	resp = h.RespondTo(ctx, "POST /reflect", httptest.MergeRequestOptions(
+		httptest.WithHeader("Content-Type", "text/plain"),
+		httptest.WithBody(strings.NewReader("Hello world")),
+	))
+	assert.Equal(t, resp.StatusCode(), 200)
+	assert.Equal(t, resp.Header().Get("Reflected-Content-Type"), "text/plain")
+	assert.Equal(t, resp.BodyString(), "Hello world")
+
 	// check WithJSONBody()
 	resp = h.RespondTo(ctx, "POST /reflect",
 		httptest.WithJSONBody([]bool{true, false, true}),
@@ -271,6 +280,17 @@ func TestRespondTo(t *testing.T) {
 		ExpectHeader(t, "Reflected-Numbers", "23"). // Header.Get() only returns first value
 		ExpectHeader(t, "Reflected-Nonsense", "").  // check that this header is absent
 		ExpectStatus(t, http.StatusOK)
+
+	// same check as the one above, rewritten to provide test coverage for Response.Expect()
+	customAssertion := func(r httptest.Response) {
+		r.ExpectHeader(t, "rEfLeCtEd-fOo", "bar")
+		r.ExpectHeader(t, "Reflected-Numbers", "23")
+		r.ExpectHeader(t, "Reflected-Nonsense", "")
+	}
+	h.RespondTo(ctx, "POST /reflect", httptest.WithHeaders(http.Header{
+		"Foo":     {"bar"},
+		"Numbers": {"23", "42"},
+	})).Expect(customAssertion).ExpectStatus(t, http.StatusOK)
 
 	// check how ExpectHeader() reports an unexpected header
 	mock.Errors = nil


### PR DESCRIPTION
As the comments explain. I was once again converting assert.HTTPRequest into Handler.RespondTo() in the Keppel test suite, and there was a lot of repetition that I would like to factor out, but the current API was too limiting.

**Draft:** Needs test coverage.