### PR TITLE
Feat: provide callback for unified custom endpoint identification

### DIFF
--- a/httpapi/compose.go
+++ b/httpapi/compose.go
@@ -22,8 +22,10 @@ func Compose(apis ...API) http.Handler {
 	// called here inside the gorilla/mux chain where route context is available.
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if name, ok := EndpointNamer(r).Unpack(); ok {
-				IdentifyEndpoint(r, name)
+			if EndpointNamer != nil {
+				if name, ok := EndpointNamer(r).Unpack(); ok {
+					IdentifyEndpoint(r, name)
+				}
 			}
 			next.ServeHTTP(w, r)
 		})

--- a/httpapi/compose.go
+++ b/httpapi/compose.go
@@ -22,8 +22,8 @@ func Compose(apis ...API) http.Handler {
 	// called here inside the gorilla/mux chain where route context is available.
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if name := EndpointNamer(r); name != nil {
-				IdentifyEndpoint(r, *name)
+			if name, ok := EndpointNamer(r).Unpack(); ok {
+				IdentifyEndpoint(r, name)
 			}
 			next.ServeHTTP(w, r)
 		})

--- a/httpapi/compose.go
+++ b/httpapi/compose.go
@@ -18,6 +18,17 @@ func Compose(apis ...API) http.Handler {
 	r := mux.NewRouter()
 	m := middleware{inner: r}
 
+	// Automatically identify the endpoint for go-bits metrics using EndpointNamer,
+	// called here inside the gorilla/mux chain where route context is available.
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if name := EndpointNamer(r); name != "" {
+				IdentifyEndpoint(r, name)
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
+
 	for _, a := range apis {
 		switch a := a.(type) {
 		case pseudoAPI:

--- a/httpapi/compose.go
+++ b/httpapi/compose.go
@@ -22,8 +22,8 @@ func Compose(apis ...API) http.Handler {
 	// called here inside the gorilla/mux chain where route context is available.
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if name := EndpointNamer(r); name != "" {
-				IdentifyEndpoint(r, name)
+			if name := EndpointNamer(r); name != nil {
+				IdentifyEndpoint(r, *name)
 			}
 			next.ServeHTTP(w, r)
 		})

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/go-bits/assert"
 	"github.com/sapcc/go-bits/httptest"
@@ -179,6 +180,80 @@ func (m metricsTestingAPI) handleRequest(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	w.Write(bytes.Repeat([]byte("."), count)) //nolint:errcheck
+}
+
+func TestEndpointNamerSetsLabel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		registry := prometheus.NewPedanticRegistry()
+		testSetRegisterer(registry)
+
+		origNamer := EndpointNamer
+		t.Cleanup(func() { EndpointNamer = origNamer })
+		EndpointNamer = func(r *http.Request) Option[string] {
+			return Some("namer-derived-endpoint")
+		}
+
+		h := httptest.NewHandler(Compose(endpointNamerTestAPI{}, WithoutLogging()))
+		resp := h.RespondTo(ctx, "GET /test-namer")
+		assert.Equal(t, resp.StatusCode(), http.StatusOK)
+
+		metricsBody := gatherMetricsText(registry)
+		if !strings.Contains(metricsBody, `endpoint="namer-derived-endpoint"`) {
+			t.Errorf("expected endpoint label \"namer-derived-endpoint\" in metrics, got:\n%s", metricsBody)
+		}
+	})
+}
+
+func TestIdentifyEndpointOverridesNamer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		registry := prometheus.NewPedanticRegistry()
+		testSetRegisterer(registry)
+
+		origNamer := EndpointNamer
+		t.Cleanup(func() { EndpointNamer = origNamer })
+		EndpointNamer = func(r *http.Request) Option[string] {
+			return Some("namer-derived-endpoint")
+		}
+
+		h := httptest.NewHandler(Compose(endpointIdentifyTestAPI{}, WithoutLogging()))
+		resp := h.RespondTo(ctx, "GET /test-identify")
+		assert.Equal(t, resp.StatusCode(), http.StatusOK)
+
+		metricsBody := gatherMetricsText(registry)
+		if !strings.Contains(metricsBody, `endpoint="handler-explicit-endpoint"`) {
+			t.Errorf("expected endpoint label \"handler-explicit-endpoint\" in metrics, got:\n%s", metricsBody)
+		}
+		if strings.Contains(metricsBody, `endpoint="namer-derived-endpoint"`) {
+			t.Error("endpoint label \"namer-derived-endpoint\" should have been overridden by IdentifyEndpoint")
+		}
+	})
+}
+
+type endpointNamerTestAPI struct{}
+
+func (a endpointNamerTestAPI) AddTo(r *mux.Router) {
+	r.Methods("GET").Path("/test-namer").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "ok", http.StatusOK)
+	})
+}
+
+type endpointIdentifyTestAPI struct{}
+
+func (a endpointIdentifyTestAPI) AddTo(r *mux.Router) {
+	r.Methods("GET").Path("/test-identify").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		IdentifyEndpoint(r, "handler-explicit-endpoint")
+		http.Error(w, "ok", http.StatusOK)
+	})
+}
+
+func gatherMetricsText(registry *prometheus.Registry) string {
+	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	rec := httptest_std.NewRecorder()
+	req := httptest_std.NewRequest("GET", "/metrics", http.NoBody)
+	h.ServeHTTP(rec, req)
+	return rec.Body.String()
 }
 
 func promhttpNormalizer(inner http.Handler) http.Handler {

--- a/httpapi/middleware.go
+++ b/httpapi/middleware.go
@@ -24,6 +24,9 @@ import (
 // Some(name) when a name can be derived, or None[string]() otherwise. If the
 // handler calls IdentifyEndpoint() explicitly, that value takes precedence over
 // the result of EndpointNamer.
+//
+// This variable must be set once during initialization (before the server
+// starts serving requests) and must not be changed concurrently.
 var EndpointNamer func(r *http.Request) Option[string] = func(r *http.Request) Option[string] {
 	return None[string]()
 }

--- a/httpapi/middleware.go
+++ b/httpapi/middleware.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/go-bits/httpext"
 	"github.com/sapcc/go-bits/logg"
@@ -22,8 +23,8 @@ import (
 // request after routing has occurred (e.g. via mux.CurrentRoute). If the
 // handler calls IdentifyEndpoint() explicitly, that value takes precedence over
 // the result of EndpointNamer.
-var EndpointNamer func(r *http.Request) *string = func(r *http.Request) *string {
-	return nil
+var EndpointNamer func(r *http.Request) Option[string] = func(r *http.Request) Option[string] {
+	return None[string]()
 }
 
 // A http.Handler middleware that adds all the special behavior for this package.
@@ -55,7 +56,6 @@ func (m middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// forward request to actual handler
 	m.inner.ServeHTTP(&writer, r)
-
 	duration := time.Since(startedAt)
 
 	// emit metrics

--- a/httpapi/middleware.go
+++ b/httpapi/middleware.go
@@ -20,7 +20,8 @@ import (
 )
 
 // EndpointNamer can be set by the application to derive the endpoint ID from a
-// request after routing has occurred (e.g. via mux.CurrentRoute). If the
+// request after routing has occurred (e.g. via mux.CurrentRoute). Return
+// Some(name) when a name can be derived, or None[string]() otherwise. If the
 // handler calls IdentifyEndpoint() explicitly, that value takes precedence over
 // the result of EndpointNamer.
 var EndpointNamer func(r *http.Request) Option[string] = func(r *http.Request) Option[string] {

--- a/httpapi/middleware.go
+++ b/httpapi/middleware.go
@@ -20,10 +20,10 @@ import (
 
 // EndpointNamer can be set by the application to derive the endpoint ID from a
 // request after routing has occurred (e.g. via mux.CurrentRoute). If the
-// endpoint ID was already set explicitly via IdentifyEndpoint(), EndpointNamer
-// is not called.
-var EndpointNamer func(r *http.Request) string = func(r *http.Request) string {
-	return "unknown"
+// handler calls IdentifyEndpoint() explicitly, that value takes precedence over
+// the result of EndpointNamer.
+var EndpointNamer func(r *http.Request) *string = func(r *http.Request) *string {
+	return nil
 }
 
 // A http.Handler middleware that adds all the special behavior for this package.

--- a/httpapi/middleware.go
+++ b/httpapi/middleware.go
@@ -18,6 +18,10 @@ import (
 	"github.com/sapcc/go-bits/logg"
 )
 
+// EndpointNamer can be set by the application to derive the endpoint ID from a
+// request after routing has occurred (e.g. via mux.CurrentRoute). If the
+// endpoint ID was already set explicitly via IdentifyEndpoint(), EndpointNamer
+// is not called.
 var EndpointNamer func(r *http.Request) string = func(r *http.Request) string {
 	return "unknown"
 }
@@ -51,10 +55,6 @@ func (m middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// forward request to actual handler
 	m.inner.ServeHTTP(&writer, r)
-
-	if endpointID == "unknown" {
-		endpointID = EndpointNamer(r)
-	}
 
 	duration := time.Since(startedAt)
 

--- a/httpapi/middleware.go
+++ b/httpapi/middleware.go
@@ -18,6 +18,10 @@ import (
 	"github.com/sapcc/go-bits/logg"
 )
 
+var EndpointNamer func(r *http.Request) string = func(r *http.Request) string {
+	return "unknown"
+}
+
 // A http.Handler middleware that adds all the special behavior for this package.
 type middleware struct {
 	inner       http.Handler
@@ -47,6 +51,11 @@ func (m middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// forward request to actual handler
 	m.inner.ServeHTTP(&writer, r)
+
+	if endpointID == "unknown" {
+		endpointID = EndpointNamer(r)
+	}
+
 	duration := time.Since(startedAt)
 
 	// emit metrics


### PR DESCRIPTION
Provide a central callback `middleware.EndpointNamer` for identifying endpoints in metrics in a single, unified manner reducing boilerplate and potential error sources.

`EndpointNamer` is assigned through a separate middleware within the `Compose` call.
It allows for a default path in case `IdentifyEndpoint` is not being used, otherwise the identifier will be overwritten.
Therefore this PR is *non breaking*.

A classical use case could be using a route name provided through the `http.Request` like so:
```
httpapibits.EndpointNamer = func(r *http.Request) string {
	if route := gorillamux.CurrentRoute(r); route != nil {
		return route.GetName()
	}
	return ""
}
```