### PR TITLE
httpapi: add func IdentifyUser

### DIFF
--- a/httpapi/compose.go
+++ b/httpapi/compose.go
@@ -53,6 +53,7 @@ const oobFunctionKey oobKey = "gobits-httpapi-oob"
 type oobMessage struct {
 	SkipLog    bool
 	EndpointID string
+	UserID     string
 }
 
 // SkipRequestLog indicates that this request shall not have a
@@ -67,9 +68,8 @@ func SkipRequestLog(r *http.Request) {
 	})
 }
 
-// IdentifyEndpoint must be called by each endpoint handler in an API that is
-// provided to Compose(). It identifies the endpoint for the purpose of HTTP
-// request/response metrics.
+// IdentifyEndpoint must be called by each endpoint handler in an API that is provided to [Compose].
+// It identifies the endpoint for the purpose of HTTP request/response metrics.
 func IdentifyEndpoint(r *http.Request, endpoint string) {
 	fn, ok := r.Context().Value(oobFunctionKey).(func(oobMessage))
 	if !ok {
@@ -77,5 +77,18 @@ func IdentifyEndpoint(r *http.Request, endpoint string) {
 	}
 	fn(oobMessage{
 		EndpointID: endpoint,
+	})
+}
+
+// IdentifyUser may be called inside an endpoint handler in an API that is provided by [Compose].
+// It identifies the requesting user within the "REQUEST" log line; the value is considered opaque and logged verbatim.
+// If this is never called for a certain request, then "-" will be printed in the log line at the respective location.
+func IdentifyUser(r *http.Request, user string) {
+	fn, ok := r.Context().Value(oobFunctionKey).(func(oobMessage))
+	if !ok {
+		panic("httpapi.IdentifyUser called from request handler outside of httpapi.Compose()!")
+	}
+	fn(oobMessage{
+		UserID: user,
 	})
 }

--- a/httpapi/middleware.go
+++ b/httpapi/middleware.go
@@ -41,6 +41,7 @@ type middleware struct {
 func (m middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	skipLog := false
 	endpointID := "unknown"
+	userID := "-"
 
 	// provide a back-channel for our custom out-of-band messages to the request handler
 	// (this is used by SkipRequestLog etc.)
@@ -50,6 +51,9 @@ func (m middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if msg.EndpointID != "" {
 			endpointID = msg.EndpointID
+		}
+		if msg.UserID != "" {
+			userID = msg.UserID
 		}
 	})
 	r = r.WithContext(ctx)
@@ -79,8 +83,8 @@ func (m middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !m.skipAllLogs {
 		if !skipLog || writer.statusCode >= 500 {
 			logg.Other(
-				"REQUEST", `%s - - "%s %s %s" %03d %d "%s" "%s" %.3fs`,
-				httpext.GetRequesterIPFor(r),
+				"REQUEST", `%s - %s "%s %s %s" %03d %d "%s" "%s" %.3fs`,
+				httpext.GetRequesterIPFor(r), userID,
 				r.Method, r.URL.String(), r.Proto,
 				writer.statusCode, writer.bytesWritten,
 				stringOrDefault("-", r.Header.Get("Referer")),


### PR DESCRIPTION
The nginx log format that our own request logging is based on does have a field `$remote_user`, but we only ever wrote `-` in it. Since it would be nice to be able to log the name or ID of requesting users for easier error tracing, this adds the facility for the application to do so.

To avoid a tight dependency between this package and e.g. gopherpolicy, the user identity shall be provided as an opaque string only, not as a token object or something like that.