### PR TITLE
audittools.MockAuditor.ExpectEvents: improve diff quality within attachments

### DIFF
--- a/audittools/auditor.go
+++ b/audittools/auditor.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sapcc/go-api-declarations/cadf"
@@ -248,9 +249,90 @@ func (a *MockAuditor) ExpectEvents(t assert.TestingT, expectedEvents ...cadf.Eve
 		return
 	}
 
+	// attach a custom Diffable to `events[_].target.attachments[_].content` to allow jsonmatch
+	// to recurse into JSON payloads within JSON strings and generate better output
+	if events, ok := expected["events"].([]any); ok {
+		for _, e := range events {
+			if event, ok := e.(map[string]any); ok {
+				if target, ok := event["target"].(map[string]any); ok {
+					if attachments, ok := target["attachments"].([]any); ok {
+						for _, a := range attachments {
+							if attachment, ok := a.(map[string]any); ok {
+								if typeURI, ok := attachment["typeURI"].(string); ok && typeURI == "mime:application/json" {
+									if content, ok := attachment["content"].(string); ok {
+										attachment["content"] = tryNewJSONWithinJSONString(content)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	for _, d := range expected.DiffAgainst(actualBuf) {
 		t.Errorf("%s", d.String())
 	}
+}
+
+// jsonWithinJSONString is a custom [jsonmatch.Diffable] that expects a JSON string whose contents match the provided Diffable.
+type jsonWithinJSONString struct {
+	inner jsonmatch.Diffable
+}
+
+// tryNewJSONWithinJSONString takes a value from `events[_].target.attachments[_].content`
+// and tries to cast it into a structured jsonmatch.Diffable.
+//
+// This is only done for content payloads that look like they benefit from being structured, not for scalar values
+// (e.g. there is not much advantage in converting `"true"` into `jsonWithinJSONString{jsonmatch.Scalar(true)}`).
+func tryNewJSONWithinJSONString(content string) any {
+	trimmed := strings.TrimSpace(content)
+	switch {
+	case strings.HasPrefix(trimmed, "{"):
+		var object jsonmatch.Object
+		err := json.Unmarshal([]byte(content), &object)
+		if err != nil {
+			return content
+		}
+		return jsonWithinJSONString{object}
+	case strings.HasPrefix(trimmed, "["):
+		var array jsonmatch.Array
+		err := json.Unmarshal([]byte(content), &array)
+		if err != nil {
+			return content
+		}
+		return jsonWithinJSONString{array}
+	default:
+		return content
+	}
+}
+
+// DiffAgainst implements the [jsonmatch.Diffable] interface.
+func (j jsonWithinJSONString) DiffAgainst(buf []byte) []jsonmatch.Diff {
+	var payload string
+	err := json.Unmarshal(buf, &payload)
+	if err != nil {
+		d := jsonmatch.Diff{
+			Kind:       fmt.Sprintf("unmarshal error (%s)", err.Error()),
+			Pointer:    "",
+			ActualJSON: strings.ToValidUTF8(string(buf), "\uFFFD"),
+		}
+		buf, err := json.Marshal(j.inner)
+		if err == nil {
+			d.ExpectedJSON = string(buf)
+		} else {
+			d.ExpectedJSON = fmt.Sprintf("<not marshalable to JSON, %%#v is %#v>", j.inner)
+		}
+		return []jsonmatch.Diff{d}
+	}
+	return j.inner.DiffAgainst([]byte(payload))
+}
+
+// MarshalJSON implements the [json.Marshaler] interface.
+// This implementation is meant to allow package jsonmatch to render better diffs.
+func (j jsonWithinJSONString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(j.inner)
 }
 
 // RecordedEvents returns the list of recorded events.

--- a/audittools/auditor_test.go
+++ b/audittools/auditor_test.go
@@ -31,12 +31,24 @@ func (mockTarget) Render() cadf.Resource {
 	return cadf.Resource{}
 }
 
+type mockComplexTarget struct {
+	Cores     int `json:"vcpu"`
+	MemoryGiB int `json:"ram"`
+}
+
+func (t mockComplexTarget) Render() cadf.Resource {
+	return cadf.Resource{
+		Name:        "dummy-server",
+		Attachments: []cadf.Attachment{must.Return(cadf.NewJSONAttachment("payload", t))},
+	}
+}
+
 func TestMockAuditor(t *testing.T) {
 	mockT := &testutil.MockT{}
 	auditor := audittools.NewMockAuditor()
 
 	// setup some dummy events
-	makeEvent := func(status int) audittools.Event {
+	makeEvent := func(status int, target audittools.Target) audittools.Event {
 		return audittools.Event{
 			Time: time.Now(),
 			Request: &http.Request{
@@ -46,7 +58,7 @@ func TestMockAuditor(t *testing.T) {
 			User:       mockUserInfo{},
 			ReasonCode: status,
 			Action:     cadf.CreateAction,
-			Target:     mockTarget{},
+			Target:     target,
 		}
 	}
 
@@ -56,14 +68,14 @@ func TestMockAuditor(t *testing.T) {
 	mockT.ExpectNoErrors(t)
 
 	// no events recorded, but one event expected -> error
-	auditor.ExpectEvents(mockT, makeEvent(http.StatusOK).ToCADF(cadf.Resource{}))
+	auditor.ExpectEvents(mockT, makeEvent(http.StatusOK, mockTarget{}).ToCADF(cadf.Resource{}))
 
 	errs := mockT.CollectedErrors()
 	assert.Equal(t, len(errs), 1)
 	assert.ErrEqual(t, errors.New(errs[0]), regexp.MustCompile(`value mismatch at /events/0: expected \{.*\}, but got <missing>`))
 
 	// one event recorded, but no events expected -> error
-	auditor.Record(makeEvent(http.StatusOK))
+	auditor.Record(makeEvent(http.StatusOK, mockTarget{}))
 	auditor.ExpectEvents(mockT, nil...)
 
 	errs = mockT.CollectedErrors()
@@ -71,8 +83,8 @@ func TestMockAuditor(t *testing.T) {
 	assert.ErrEqual(t, errors.New(errs[0]), regexp.MustCompile(`value mismatch at /events/0: expected <missing>, but got \{.*\}`))
 
 	// one event recorded, but a different event expected -> error
-	auditor.Record(makeEvent(http.StatusOK))
-	auditor.ExpectEvents(mockT, makeEvent(http.StatusNotFound).ToCADF(cadf.Resource{}))
+	auditor.Record(makeEvent(http.StatusOK, mockTarget{}))
+	auditor.ExpectEvents(mockT, makeEvent(http.StatusNotFound, mockTarget{}).ToCADF(cadf.Resource{}))
 
 	mockT.ExpectErrors(t,
 		`value mismatch at /events/0/outcome: expected "failure", but got "success"`,
@@ -80,8 +92,17 @@ func TestMockAuditor(t *testing.T) {
 	)
 
 	// one event recorded, and that same event expected -> success
-	auditor.Record(makeEvent(http.StatusOK))
-	auditor.ExpectEvents(mockT, makeEvent(http.StatusOK).ToCADF(cadf.Resource{}))
+	auditor.Record(makeEvent(http.StatusOK, mockTarget{}))
+	auditor.ExpectEvents(mockT, makeEvent(http.StatusOK, mockTarget{}).ToCADF(cadf.Resource{}))
 
 	mockT.ExpectNoErrors(t)
+
+	// check error reporting for diffs within JSON attachments
+	auditor.Record(makeEvent(http.StatusOK, mockComplexTarget{Cores: 2, MemoryGiB: 4}))
+	auditor.ExpectEvents(mockT, makeEvent(http.StatusOK, mockComplexTarget{Cores: 3, MemoryGiB: 6}).ToCADF(cadf.Resource{}))
+
+	mockT.ExpectErrors(t,
+		`value mismatch at /events/0/target/attachments/0/content/ram: expected 6, but got 4`,
+		`value mismatch at /events/0/target/attachments/0/content/vcpu: expected 3, but got 2`,
+	)
 }


### PR DESCRIPTION
I was working on Limes v2 API tests that include audit event assertions, and came into a lot of pain because of the weird encoding for attachments being opaque to jsonmatch by default. This is what I had to deal with:

```
commitment_create_test.go:101: value mismatch at /events/0/target/attachments/0/content: expected "{\"az\":\"az-one\",\"byProject\":{\"uuid-for-berlin\":{\"byResource\":{\"capacity\":{\"commitments\":[{\"amount\":1,\"confirmBy\":\"1970-01-01T00:00:00Z\",\"expiresAt\":\"1970-01-01T01:00:00Z\",\"newStatus\":\"pending\",\"oldStatus\":null,\"uuid\":\"b9d86ae1-bd4d-4060-b989-397d131b9eec\"}],\"totalConfirmedAfter\":0,\"totalConfirmedBefore\":0,\"totalGuaranteedAfter\":0,\"totalGuaranteedBefore\":0}}}},\"dryRun\":false,\"infoVersion\":1}", but got "{\"az\":\"az-one\",\"dryRun\":false,\"infoVersion\":1,\"byProject\":{\"uuid-for-berlin\":{\"byResource\":{\"capacity\":{\"totalConfirmedBefore\":0,\"totalConfirmedAfter\":0,\"totalGuaranteedBefore\":0,\"totalGuaranteedAfter\":0,\"commitments\":[{\"uuid\":\"b9d86ae1-bd4d-4060-b989-397d131b9eec\",\"oldStatus\":null,\"newStatus\":\"pending\",\"amount\":1,\"confirmBy\":\"1970-01-01T01:00:00+01:00\",\"expiresAt\":\"1970-01-01T02:00:00+01:00\"}]}}}}}"
```

For comparison, the same diff after this patch:

```
commitment_create_test.go:101: value mismatch at /events/0/target/attachments/0/content/byProject/uuid-for-berlin/byResource/capacity/commitments/0/confirmBy: expected "1970-01-01T00:00:00Z", but got "1970-01-01T01:00:00+01:00"
commitment_create_test.go:101: value mismatch at /events/0/target/attachments/0/content/byProject/uuid-for-berlin/byResource/capacity/commitments/0/expiresAt: expected "1970-01-01T01:00:00Z", but got "1970-01-01T02:00:00+01:00"
```