### PR TITLE
respondwith: add CustomHeader

### DIFF
--- a/respondwith/error.go
+++ b/respondwith/error.go
@@ -7,12 +7,12 @@ import (
 	"net/http"
 )
 
-func analyzeError(err error) (message string, status int) {
+func analyzeError(err error) (message string, status int, hdr http.Header) {
 	switch err := err.(type) { //nolint:errorlint // wrapped errors are intentionally ignored, see doc on func CustomStatus()
 	case errorWithCustomStatus:
-		return err.Inner.Error(), err.Status
+		return err.Inner.Error(), err.Status, err.Header
 	default:
-		return err.Error(), http.StatusInternalServerError
+		return err.Error(), http.StatusInternalServerError, nil
 	}
 }
 
@@ -56,18 +56,23 @@ func analyzeError(err error) (message string, status int) {
 // This rule prevents sensitive data in the outermost error's message from accidentally leaking through respondwith.ObfuscatedErrorText().
 //
 // CustomStatus panics when called with a nil error or a non-error status (only 400..599 status codes are allowed).
-func CustomStatus(status int, inner error) error {
+func CustomStatus(status int, inner error, opts ...CustomOption) error {
 	if inner == nil {
 		panic("CustomStatus called with inner == nil")
 	}
 	if status < 400 || status >= 600 {
 		panic("CustomStatus called with a non-error status (only 400..599 are allowed)")
 	}
-	return errorWithCustomStatus{status, inner}
+	result := errorWithCustomStatus{status, make(http.Header), inner}
+	for _, opt := range opts {
+		opt(&result)
+	}
+	return result
 }
 
 type errorWithCustomStatus struct { //nolint:errname // I won't put "error" at the end because "customStatusHavingError" sounds stupid
 	Status int
+	Header http.Header
 	Inner  error
 }
 
@@ -79,4 +84,23 @@ func (e errorWithCustomStatus) Error() string {
 // Unwrap implements the unnamed interface implied by package errors.
 func (e errorWithCustomStatus) Unwrap() error {
 	return e.Inner
+}
+
+// CustomOption provides additional behavior to func [CustomStatus].
+type CustomOption func(*errorWithCustomStatus)
+
+// CustomHeader adds an HTTP header to an error response built by func [CustomStatus].
+// For example:
+//
+//	return respondwith.CustomStatus(
+//		http.StatusTooManyRequests,
+//		fmt.Errorf("ratelimit exceeded (limit = %d, used = %d, resetAt = %s)",
+//			result.Limit, result.Used, result.ResetAt.Format(time.RFC3339)),
+//		respondwith.CustomHeader("Retry-After",
+//			strconv.Itoa(time.Until(result.ResetAt).Seconds())),
+//	)
+func CustomHeader(key, value string) CustomOption {
+	return func(e *errorWithCustomStatus) {
+		e.Header.Add(key, value)
+	}
 }

--- a/respondwith/error_test.go
+++ b/respondwith/error_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package respondwith_test
+
+import (
+	"errors"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"go.xyrillian.de/gg/jsonmatch"
+
+	"github.com/sapcc/go-bits/assert"
+	"github.com/sapcc/go-bits/httptest"
+	"github.com/sapcc/go-bits/respondwith"
+)
+
+func TestCustomStatus(t *testing.T) {
+	ctx := t.Context()
+
+	exampleHandler := func(r *http.Request) (map[string]any, error) {
+		switch r.URL.Path {
+		case "/ok":
+			return map[string]any{"success": true}, nil
+		case "/servererror":
+			return nil, errors.New("datacenter on fire")
+		case "/ratelimit":
+			return nil, respondwith.CustomStatus(http.StatusTooManyRequests,
+				errors.New("ratelimit exceeded"),
+				respondwith.CustomHeader("Retry-After", "60"),
+			)
+		default:
+			return nil, respondwith.CustomStatus(http.StatusNotFound, errors.New("not found"))
+		}
+	}
+
+	plainHandler := httptest.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result, err := exampleHandler(r)
+		if respondwith.ErrorText(w, err) {
+			return
+		}
+		respondwith.JSON(w, http.StatusOK, result)
+	}))
+
+	obfuscatedHandler := httptest.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result, err := exampleHandler(r)
+		if respondwith.ObfuscatedErrorText(w, err) {
+			return
+		}
+		respondwith.JSON(w, http.StatusOK, result)
+	}))
+
+	plainHandler.RespondTo(ctx, "GET /ok").
+		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"success": true})
+	obfuscatedHandler.RespondTo(ctx, "GET /ok").
+		ExpectJSON(t, http.StatusOK, jsonmatch.Object{"success": true})
+
+	plainHandler.RespondTo(ctx, "GET /servererror").
+		ExpectText(t, http.StatusInternalServerError, "datacenter on fire\n")
+	obfuscatedHandler.RespondTo(ctx, "GET /servererror").Expect(func(r httptest.Response) {
+		r.ExpectStatus(t, http.StatusInternalServerError)
+		assert.Equal(t, regexp.MustCompile(`^Internal Server Error \(ID = .*\)\n$`).MatchString(r.BodyString()), true)
+	})
+
+	plainHandler.RespondTo(ctx, "GET /notfound").
+		ExpectText(t, http.StatusNotFound, "not found\n")
+	obfuscatedHandler.RespondTo(ctx, "GET /notfound").
+		ExpectText(t, http.StatusNotFound, "not found\n")
+
+	plainHandler.RespondTo(ctx, "GET /ratelimit").
+		ExpectHeader(t, "Retry-After", "60").
+		ExpectText(t, http.StatusTooManyRequests, "ratelimit exceeded\n")
+	obfuscatedHandler.RespondTo(ctx, "GET /ratelimit").
+		ExpectHeader(t, "Retry-After", "60").
+		ExpectText(t, http.StatusTooManyRequests, "ratelimit exceeded\n")
+}

--- a/respondwith/pkg.go
+++ b/respondwith/pkg.go
@@ -9,6 +9,7 @@ package respondwith
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 
 	"github.com/gofrs/uuid/v5"
@@ -54,7 +55,8 @@ func ErrorText(w http.ResponseWriter, err error) bool {
 		return false
 	}
 
-	message, status := analyzeError(err)
+	message, status, hdr := analyzeError(err)
+	maps.Copy(w.Header(), hdr)
 	http.Error(w, message, status)
 	return true
 }
@@ -80,13 +82,14 @@ func ObfuscatedErrorText(w http.ResponseWriter, err error) bool {
 		return false
 	}
 
-	message, status := analyzeError(err)
+	message, status, hdr := analyzeError(err)
 	if status >= 500 {
 		logUUID := must.Return(uuid.NewV4()).String()
 		logg.Error("%s is: %s", logUUID, message)
 		message = fmt.Sprintf("Internal Server Error (ID = %s)", logUUID)
 	}
 
+	maps.Copy(w.Header(), hdr)
 	http.Error(w, message, status)
 	return true
 }


### PR DESCRIPTION
The intended usecase is exactly the one shown. Limes wants to be able to render `Retry-After` headers as part of errors (during commitment creation, the liquid may answer with a Retry-After hint).