### PR TITLE
add JQModifiableJSONString and ModifyWithVariable

### DIFF
--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -30,7 +30,8 @@ reuse:
   annotations:
     - paths:
       - httpapi/fixtures/metrics.prom
-      - httptest/fixtures/example.*
+      - httptest/fixtures/*.json
+      - httptest/fixtures/*.txt
       - tools/release-info/go.mod
       SPDX-FileCopyrightText: SAP SE or an SAP affiliate company
       SPDX-License-Identifier: Apache-2.0

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -29,7 +29,8 @@ SPDX-License-Identifier = "Apache-2.0"
 [[annotations]]
 path = [
   "httpapi/fixtures/metrics.prom",
-  "httptest/fixtures/example.*",
+  "httptest/fixtures/*.json",
+  "httptest/fixtures/*.txt",
   "tools/release-info/go.mod",
 ]
 SPDX-FileCopyrightText = "SAP SE or an SAP affiliate company"

--- a/httptest/fixtures/example.json
+++ b/httptest/fixtures/example.json
@@ -1,17 +1,17 @@
 {
-  "string_field": "hello",
-  "int_field": 42,
-  "float_field": 3.14,
-  "bool_true": true,
-  "bool_false": false,
-  "null_field": null,
-  "nested_object": {
-    "inner_string": "world",
-    "inner_int": 7
-  },
+  "also_remove": "should also be deleted",
   "array_field": [1, "two", true, null, 4.5],
+  "bool_false": false,
+  "bool_true": true,
+  "float_field": 3.14,
+  "int_field": 42,
   "nested_array": [[1, 2], [3, 4]],
+  "nested_object": {
+    "inner_int": 7,
+    "inner_string": "world"
+  },
+  "null_field": null,
   "object_in_array": [{"name": "alice"}, {"name": "bob"}],
   "remove_me": "should be deleted",
-  "also_remove": "should also be deleted"
+  "string_field": "hello"
 }

--- a/httptest/fixtures/modification.json
+++ b/httptest/fixtures/modification.json
@@ -1,0 +1,1 @@
+{"bool_false2": false, "nested_object": {"inner_string2": "space"}}

--- a/httptest/jq_fixtures.go
+++ b/httptest/jq_fixtures.go
@@ -5,59 +5,135 @@ package httptest
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/itchyny/gojq"
 	"go.xyrillian.de/gg/jsonmatch"
 )
 
-// JQModifiableJSONFixture represents a JSON fixture file, that can be
-// modified with jq syntax before converting it a jsonmatch.Diffable format.
-// We do not save it back to a modified fixture file, so that we circumvent
-// all the possible problems of JSON-fixture files.
-type JQModifiableJSONFixture struct {
-	filePath        string
+// JQUnmodifiedContent is an interface to represent types that can be used as
+// variables in jq expressions, but cannot be modified themselves.
+type JQUnmodifiedContent interface {
+	parse() (any, error)
+}
+
+// JQUnmodifiedJSONString makes a string containing a raw JSON payload
+// available as [JQUnmodifiedContent] for a ModifyWithVariable() call on a [JQModifiableContent].
+func JQUnmodifiedJSONString(value string) JQUnmodifiedContent {
+	return jqUnmodifiedJSONString(value)
+}
+
+type jqUnmodifiedJSONString string
+
+// parse implements the [JQUnmodifiedContent] interface.
+func (j jqUnmodifiedJSONString) parse() (any, error) {
+	var parsed any
+	err := json.Unmarshal([]byte(j), &parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse input: %w", err)
+	}
+	return parsed, nil
+}
+
+// JQUnmodifiedJSONFixture makes a JSON fixture file available as
+// [JQUnmodifiedContent] for a ModifyWithVariable() call on a [JQModifiableContent].
+func JQUnmodifiedJSONFixture(value string) JQUnmodifiedContent {
+	return jqUnmodifiedJSONFixture(value)
+}
+
+type jqUnmodifiedJSONFixture string
+
+// parse implements the [JQUnmodifiedContent] interface.
+func (j jqUnmodifiedJSONFixture) parse() (any, error) {
+	pathString := string(j)
+	originalJSON, err := os.ReadFile(pathString)
+	if err != nil {
+		return "", fmt.Errorf("failed to read fixture file %s: %w", pathString, err)
+	}
+	jAsString := jqUnmodifiedJSONString(originalJSON)
+	parsed, err := jAsString.parse()
+	if err != nil {
+		return nil, fmt.Errorf("failed to process fixture file %s: %w", pathString, err)
+	}
+	return parsed, nil
+}
+
+// JQModifiableContent is an interface to represent types that can be modified
+// with jq expressions.
+type JQModifiableContent interface {
+	jsonmatch.Diffable
+	json.Marshaler
+	// Modify appends one or more jq expressions that will be applied to the
+	// modifiable content when functions from the [jsonmatch.Diffable]
+	// interface are called. Multiple modifications are piped together in the
+	// order they were added. The receiver is returned to allow method chaining.
+	Modify(modifications ...string) JQModifiableContent
+	// ModifyWithVariable appends one jq expression that will be applied to the
+	// modifiable content when functions from the [jsonmatch.Diffable]
+	// interface are called. Contrary to Modify, it can reference a variable via
+	// the statically defined "$ref" variable. Multiple modifications are piped
+	// together in the order they were added. The receiver is returned to allow
+	// method chaining.
+	ModifyWithVariable(modification string, ref JQUnmodifiedContent) JQModifiableContent
+}
+
+// jqModifiableJSONString represents a JSON string, that can be modified
+// with jq syntax and implements the [jsonmatch.Diffable] interface.
+type jqModifiableJSONString struct {
+	jsonString      string
+	refs            []JQUnmodifiedContent
 	testIdentifier  string
 	jqModifications []string
 }
 
-// NewJQModifiableJSONFixture creates a new JQModifiableJSONFixture for the
-// given fixture file path. The testIdentifier is used in error messages to
+// NewJQModifiableJSONString creates a new [JQModifiableContent] for the
+// given JSON string. The testIdentifier is used in error messages to
 // help identify which test caused a failure.
-func NewJQModifiableJSONFixture(filePath, testIdentifier string) JQModifiableJSONFixture {
-	return JQModifiableJSONFixture{
-		filePath:       filePath,
+func NewJQModifiableJSONString(jsonString, testIdentifier string) JQModifiableContent {
+	return jqModifiableJSONString{
+		jsonString:     jsonString,
 		testIdentifier: testIdentifier,
 	}
 }
 
-// Modify appends one or more jq expressions that will be applied to the
-// fixture's JSON content when converting it to a jsonmatch.Diffable. Multiple
-// modifications are piped together in the order they were added. The receiver
-// is returned to allow method chaining.
-func (j JQModifiableJSONFixture) Modify(modifications ...string) JQModifiableJSONFixture {
+// Modify implements the [JQModifiableContent] interface.
+func (j jqModifiableJSONString) Modify(modifications ...string) JQModifiableContent {
 	result := j
 	result.jqModifications = append(slices.Clone(j.jqModifications), modifications...)
 	return result
 }
 
-// ToDiffable reads the JSON fixture file, applies all accumulated jq
-// modifications, and converts the result into a jsonmatch.Diffable. It returns
-// an error if the file cannot be read, the JSON is malformed, the jq expression
-// is invalid, or the expression produces multiple results.
-func (j JQModifiableJSONFixture) toDiffable() (diffable jsonmatch.Diffable, err error) {
-	originalJSON, err := os.ReadFile(j.filePath)
+// ModifyWithVariable implements the [JQModifiableContent] interface.
+func (j jqModifiableJSONString) ModifyWithVariable(modification string, ref JQUnmodifiedContent) JQModifiableContent {
+	result := j
+	result.jqModifications = append(slices.Clone(j.jqModifications), modification)
+	result.refs = append(slices.Clone(j.refs), ref)
+	return result
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (j jqModifiableJSONString) MarshalJSON() ([]byte, error) {
+	diffable, err := j.toDiffable()
 	if err != nil {
-		return diffable, fmt.Errorf("failed to read fixture file %s: %w", j.filePath, err)
+		return nil, err
 	}
+	return json.Marshal(diffable)
+}
+
+// toDiffable parses the JSON string, applies all accumulated jq
+// modifications, and converts the result into a jsonmatch.Diffable. It returns
+// an error if the JSON is malformed, the jq expression is invalid,
+// or the expression produces multiple results.
+func (j jqModifiableJSONString) toDiffable() (diffable jsonmatch.Diffable, err error) {
 	var parsedInput any
-	err = json.Unmarshal(originalJSON, &parsedInput)
+	err = json.Unmarshal([]byte(j.jsonString), &parsedInput)
 	if err != nil {
-		return diffable, fmt.Errorf("failed to parse fixture file %s: %w", j.filePath, err)
+		return diffable, fmt.Errorf("failed to parse input for test %q: %w", j.testIdentifier, err)
 	}
 
 	// early return for no modifications
@@ -65,22 +141,42 @@ func (j JQModifiableJSONFixture) toDiffable() (diffable jsonmatch.Diffable, err 
 		// convert raw input
 		diffable, err = convertRecursively(parsedInput)
 		if err != nil {
-			return diffable, fmt.Errorf("failed to convert raw input to jsonmatch for test %s: %w", j.testIdentifier, err)
+			return diffable, fmt.Errorf("failed to convert raw input to jsonmatch for test %q: %w", j.testIdentifier, err)
 		}
 		return diffable, nil
 	}
 
-	// do jq modifications
+	// prepare refs
 	jqModification := strings.Join(j.jqModifications, " | ")
+	refRegex := regexp.MustCompile(`\$ref\b`)
+	i := 0
+	jqModification = string(refRegex.ReplaceAllFunc([]byte(jqModification), func(match []byte) []byte {
+		i++
+		return []byte("$ref" + strconv.Itoa(i))
+	}))
+	if i != len(j.refs) {
+		return diffable, fmt.Errorf("different number of $ref used than provided for test %q: %d used, %d provided", j.testIdentifier, i, len(j.refs))
+	}
+	refVars := make([]string, len(j.refs))
+	refStrings := make([]any, len(j.refs))
+	for i, ref := range j.refs {
+		refVars[i] = "$ref" + strconv.Itoa(i+1)
+		refStrings[i], err = ref.parse()
+		if err != nil {
+			return diffable, fmt.Errorf("failed to read data for $ref #%d for test %q: %w", i+1, j.testIdentifier, err)
+		}
+	}
+
+	// do jq modifications
 	query, err := gojq.Parse(jqModification)
 	if err != nil {
-		return diffable, fmt.Errorf("failed to parse query for test %s: %w", j.testIdentifier, err)
+		return diffable, fmt.Errorf("failed to parse query for test %q: %w", j.testIdentifier, err)
 	}
-	code, err := gojq.Compile(query)
+	code, err := gojq.Compile(query, gojq.WithVariables(refVars))
 	if err != nil {
-		return diffable, fmt.Errorf("failed to compile query for test %s: %w", j.testIdentifier, err)
+		return diffable, fmt.Errorf("failed to compile query for test %q: %w", j.testIdentifier, err)
 	}
-	iter := code.Run(parsedInput)
+	iter := code.Run(parsedInput, refStrings...)
 	var modifiedInput any
 	for i := range 2 {
 		v, ok := iter.Next()
@@ -88,10 +184,10 @@ func (j JQModifiableJSONFixture) toDiffable() (diffable jsonmatch.Diffable, err 
 			break
 		}
 		if i > 0 {
-			return diffable, errors.New("modifications which produce multiple results are not supported")
+			return diffable, fmt.Errorf("failed to apply modifications for test %q: modifications which produce multiple results are not supported", j.testIdentifier)
 		}
 		if err, ok = v.(error); ok {
-			return diffable, fmt.Errorf("failed to apply modifications for test %s: %w", j.testIdentifier, err)
+			return diffable, fmt.Errorf("failed to apply modifications for test %q: %w", j.testIdentifier, err)
 		}
 		modifiedInput = v
 	}
@@ -99,13 +195,96 @@ func (j JQModifiableJSONFixture) toDiffable() (diffable jsonmatch.Diffable, err 
 	// convert modified input
 	diffable, err = convertRecursively(modifiedInput)
 	if err != nil {
-		return diffable, fmt.Errorf("failed to convert modifications to jsonmatch for test %s: %w", j.testIdentifier, err)
+		return diffable, fmt.Errorf("failed to convert modifications to jsonmatch for test %q: %w", j.testIdentifier, err)
 	}
 	return diffable, nil
 }
 
-// DiffAgainst implements the [jsonmatch.Diffable] interface.
-func (j JQModifiableJSONFixture) DiffAgainst(buf []byte) []jsonmatch.Diff {
+// DiffAgainst implements the [JQModifiableContent] interface.
+func (j jqModifiableJSONString) DiffAgainst(buf []byte) []jsonmatch.Diff {
+	diffable, err := j.toDiffable()
+	if err != nil {
+		return []jsonmatch.Diff{{
+			Kind:         fmt.Sprintf("JSON string processing error (%s)", err.Error()),
+			Pointer:      "",
+			ExpectedJSON: "<unknown>",
+			ActualJSON:   strings.ToValidUTF8(string(buf), "\uFFFD"),
+		}}
+	}
+	return diffable.DiffAgainst(buf)
+}
+
+// jqModifiableJSONFixture represents a JSON fixture file, that can be
+// modified with jq syntax and implements the jsonmatch.Diffable interface.
+// We do not save it back to a modified fixture file, so that we circumvent
+// all the possible problems of JSON-fixture files.
+type jqModifiableJSONFixture struct {
+	filePath        string
+	refs            []JQUnmodifiedContent
+	testIdentifier  string
+	jqModifications []string
+}
+
+// NewJQModifiableJSONFixture creates a new [JQModifiableContent] for the
+// given JSON fixture file path. The testIdentifier is used in error messages to
+// help identify which test caused a failure.
+func NewJQModifiableJSONFixture(filePath, testIdentifier string) JQModifiableContent {
+	return jqModifiableJSONFixture{
+		filePath:       filePath,
+		testIdentifier: testIdentifier,
+	}
+}
+
+// Modify implements the [JQModifiableContent] interface.
+func (j jqModifiableJSONFixture) Modify(modifications ...string) JQModifiableContent {
+	result := j
+	result.jqModifications = append(slices.Clone(j.jqModifications), modifications...)
+	return result
+}
+
+// ModifyWithVariable implements the [JQModifiableContent] interface.
+func (j jqModifiableJSONFixture) ModifyWithVariable(modification string, ref JQUnmodifiedContent) JQModifiableContent {
+	result := j
+	result.jqModifications = append(slices.Clone(j.jqModifications), modification)
+	result.refs = append(slices.Clone(j.refs), ref)
+	return result
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (j jqModifiableJSONFixture) MarshalJSON() ([]byte, error) {
+	diffable, err := j.toDiffable()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(diffable)
+}
+
+// toDiffable reads the JSON fixture file, applies all accumulated jq
+// modifications, and converts the result into a jsonmatch.Diffable. It returns
+// an error if the file cannot be read, the JSON is malformed, the jq expression
+// is invalid, or the expression produces multiple results.
+func (j jqModifiableJSONFixture) toDiffable() (diffable jsonmatch.Diffable, err error) {
+	originalJSON, err := os.ReadFile(j.filePath)
+	if err != nil {
+		return diffable, fmt.Errorf("failed to read fixture file %s: %w", j.filePath, err)
+	}
+
+	// handle as string to share code
+	stringRepresentation := jqModifiableJSONString{
+		jsonString:      string(originalJSON),
+		refs:            j.refs,
+		testIdentifier:  j.testIdentifier,
+		jqModifications: j.jqModifications,
+	}
+	diffable, err = stringRepresentation.toDiffable()
+	if err != nil {
+		return diffable, fmt.Errorf("failed to process fixture file %s: %w", j.filePath, err)
+	}
+	return diffable, nil
+}
+
+// DiffAgainst implements the [JQModifiableContent] interface.
+func (j jqModifiableJSONFixture) DiffAgainst(buf []byte) []jsonmatch.Diff {
 	diffable, err := j.toDiffable()
 	if err != nil {
 		return []jsonmatch.Diff{{

--- a/httptest/jq_fixtures_test.go
+++ b/httptest/jq_fixtures_test.go
@@ -1,15 +1,19 @@
 // SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
 // SPDX-License-Identifier: Apache-2.0
 
-package httptest
+package httptest_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"testing"
 
 	"go.xyrillian.de/gg/assert"
 	"go.xyrillian.de/gg/jsonmatch"
+
+	"github.com/sapcc/go-bits/httptest"
+	"github.com/sapcc/go-bits/must"
 )
 
 func expectNoDiffs(t *testing.T, diffs []jsonmatch.Diff) {
@@ -19,9 +23,9 @@ func expectNoDiffs(t *testing.T, diffs []jsonmatch.Diff) {
 	}
 }
 
-func TestToDiffable(t *testing.T) {
+func TestJQModifiableJSONFixtureSimple(t *testing.T) {
 	// no transformations
-	diffable := NewJQModifiableJSONFixture("fixtures/example.json", "TestToDiffableWithDotModification").Modify(".").Modify(".")
+	diffable := httptest.NewJQModifiableJSONFixture("fixtures/example.json", "TestJQModifiableJSONFixture with dot modification").Modify(".").Modify(".")
 	originalJSON, err := os.ReadFile("fixtures/example.json")
 	if err != nil {
 		t.Error("could not read original test fixture file")
@@ -29,46 +33,50 @@ func TestToDiffable(t *testing.T) {
 	expectNoDiffs(t, diffable.DiffAgainst(originalJSON))
 
 	// no modifications at all
-	diffable = NewJQModifiableJSONFixture("fixtures/example.json", "TestToDiffableWithoutModifications")
+	diffable = httptest.NewJQModifiableJSONFixture("fixtures/example.json", "TestJQModifiableJSONFixture without modification")
 	expectNoDiffs(t, diffable.DiffAgainst(originalJSON))
 
 	// 2 deletions in a row
-	diffable = NewJQModifiableJSONFixture("fixtures/example.json", "TestToDiffableWithChainedDeletions").Modify(
+	diffable = httptest.NewJQModifiableJSONFixture("fixtures/example.json", "TestJQModifiableJSONFixture with chained deletions").Modify(
 		`del(.remove_me)`, `del(.also_remove)`,
 	)
-	expected := bytes.Replace(originalJSON, []byte(`,
-  "remove_me": "should be deleted",
-  "also_remove": "should also be deleted"`), []byte(""), 1)
+	expected := bytes.Replace(originalJSON, []byte(`  "remove_me": "should be deleted",
+`), []byte(""), 1)
+	expected = bytes.Replace(expected, []byte(`  "also_remove": "should also be deleted",
+`), []byte(""), 1)
 	expectNoDiffs(t, diffable.DiffAgainst(expected))
 
 	// 2 deletions with 2 modifications
-	diffable = NewJQModifiableJSONFixture("fixtures/example.json", "TestToDiffableWithChainedModifications").Modify(
+	diffable = httptest.NewJQModifiableJSONFixture("fixtures/example.json", "TestJQModifiableJSONFixture with chained modifications").Modify(
 		`del(.remove_me, .also_remove)`,
 		`.string_field = "modified"`,
 		`.nested_object.inner_string = "changed"`,
 	)
-	expected = bytes.Replace(expected, []byte(`  "string_field": "hello",`), []byte(`  "string_field": "modified",`), 1)
-	expected = bytes.Replace(expected, []byte(`    "inner_string": "world",`), []byte(`    "inner_string": "changed",`), 1)
+	expected = bytes.Replace(expected, []byte(`  "string_field": "hello"`), []byte(`  "string_field": "modified"`), 1)
+	expected = bytes.Replace(expected, []byte(`    "inner_string": "world"`), []byte(`    "inner_string": "changed"`), 1)
 	expectNoDiffs(t, diffable.DiffAgainst(expected))
 
+	// check that the serialization works
+	assert.Equal(t, must.ReturnT(json.Marshal(diffable))(t), bytes.ReplaceAll(bytes.ReplaceAll(expected, []byte("\n"), []byte("")), []byte(" "), []byte("")))
+
 	// int overflow
-	diffable = NewJQModifiableJSONFixture("fixtures/example.json", "TestToDiffableWithIntOverflow").Modify(
+	diffable = httptest.NewJQModifiableJSONFixture("fixtures/example.json", "TestJQModifiableJSONFixture with int overflow").Modify(
 		`. + {"big": (9999999999999999999 * 9999999999999999999)}`,
 	)
 	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
-		`fixture processing error (failed to convert modifications to jsonmatch for test TestToDiffableWithIntOverflow: received unsupported type from gojq *big.Int): expected <unknown>, but got something`,
+		`fixture processing error (failed to process fixture file fixtures/example.json: failed to convert modifications to jsonmatch for test "TestJQModifiableJSONFixture with int overflow": received unsupported type from gojq *big.Int): expected <unknown>, but got something`,
 	)
 
 	// multiple result statements
-	diffable = NewJQModifiableJSONFixture("fixtures/example.json", "TestToDiffableWithMultipleResults").Modify(
+	diffable = httptest.NewJQModifiableJSONFixture("fixtures/example.json", "TestJQModifiableJSONFixture with multiple results").Modify(
 		".string_field, .int_field",
 	)
 	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
-		`fixture processing error (modifications which produce multiple results are not supported): expected <unknown>, but got something`,
+		`fixture processing error (failed to process fixture file fixtures/example.json: failed to apply modifications for test "TestJQModifiableJSONFixture with multiple results": modifications which produce multiple results are not supported): expected <unknown>, but got something`,
 	)
 
 	// non-existent file
-	diffable = NewJQModifiableJSONFixture("fixtures/nonexistent.json", "TestToDiffableFileNotFound").Modify(
+	diffable = httptest.NewJQModifiableJSONFixture("fixtures/nonexistent.json", "TestJQModifiableJSONFixture file not found").Modify(
 		".",
 	)
 	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
@@ -76,18 +84,154 @@ func TestToDiffable(t *testing.T) {
 	)
 
 	// invalid json
-	diffable = NewJQModifiableJSONFixture("fixtures/example.txt", "TestToDiffableInvalidJSON").Modify(
+	diffable = httptest.NewJQModifiableJSONFixture("fixtures/example.txt", "TestJQModifiableJSONFixture invalid json").Modify(
 		".",
 	)
 	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
-		`fixture processing error (failed to parse fixture file fixtures/example.txt: invalid character 'H' looking for beginning of value): expected <unknown>, but got something`,
+		`fixture processing error (failed to process fixture file fixtures/example.txt: failed to parse input for test "TestJQModifiableJSONFixture invalid json": invalid character 'H' looking for beginning of value): expected <unknown>, but got something`,
 	)
 
 	// invalid jq expression
-	diffable = NewJQModifiableJSONFixture("fixtures/example.json", "TestToDiffableInvalidJQ").Modify(
+	diffable = httptest.NewJQModifiableJSONFixture("fixtures/example.json", "TestJQModifiableJSONFixture invalid jq").Modify(
 		"invalid jq [[[ syntax",
 	)
 	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
-		`fixture processing error (failed to parse query for test TestToDiffableInvalidJQ: unexpected token "jq"): expected <unknown>, but got something`,
+		`fixture processing error (failed to process fixture file fixtures/example.json: failed to parse query for test "TestJQModifiableJSONFixture invalid jq": unexpected token "jq"): expected <unknown>, but got something`,
+	)
+}
+
+const testString = `
+	{
+		"string_field": "hello",
+		"int_field": 42,
+		"float_field": 3.14,
+		"bool_true": true,
+		"bool_false": false,
+		"null_field": null,
+		"nested_object": {
+			"inner_string": "world",
+			"inner_int": 7
+		},
+		"array_field": [1, "two", true, null, 4.5],
+		"nested_array": [[1, 2], [3, 4]],
+		"object_in_array": [{"name": "alice"}, {"name": "bob"}],
+		"remove_me": "should be deleted",
+		"also_remove": "should also be deleted"
+	}`
+
+func TestJQModifiableJSONStringSimple(t *testing.T) {
+	// These are just simple cases because the code is actually shared
+	// no transformations
+
+	diffable := httptest.NewJQModifiableJSONString(testString, "TestJQModifiableJSONString with dot modification").Modify(".").Modify(".")
+	originalJSON, err := os.ReadFile("fixtures/example.json")
+	if err != nil {
+		t.Error("could not read original test fixture file")
+	}
+	expectNoDiffs(t, diffable.DiffAgainst(originalJSON))
+
+	// no modifications at all
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableJSONString without modifications")
+	expectNoDiffs(t, diffable.DiffAgainst(originalJSON))
+
+	// 2 deletions in a row
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableJSONString with chained deletions").Modify(
+		`del(.remove_me)`, `del(.also_remove)`,
+	)
+	expected := bytes.Replace(originalJSON, []byte(`  "remove_me": "should be deleted",
+`), []byte(""), 1)
+	expected = bytes.Replace(expected, []byte(`  "also_remove": "should also be deleted",
+`), []byte(""), 1)
+	expectNoDiffs(t, diffable.DiffAgainst(expected))
+
+	// check that the serialization works
+	assert.Equal(t, must.ReturnT(json.Marshal(diffable))(t), bytes.ReplaceAll(bytes.ReplaceAll(expected, []byte("\n"), []byte("")), []byte(" "), []byte("")))
+}
+
+func TestJQModifiableContentWithVariables(t *testing.T) {
+	// assemble a JSON fixture where we place strings in a few places
+	originalJSON, err := os.ReadFile("fixtures/example.json")
+	if err != nil {
+		t.Error("could not read original test fixture file")
+	}
+	expected := bytes.Replace(originalJSON, []byte(`"bool_false": false,
+`), []byte(`"bool_false": false,
+  "bool_false2": false,
+`), 1)
+	expected = bytes.Replace(expected, []byte(`"inner_string": "world"
+`), []byte(`"inner_string": "world",
+    "inner_string2": "space"
+`), 1)
+
+	diffable := httptest.NewJQModifiableJSONFixture("fixtures/example.json", "TestJQModifiableContentWithVariables deep merge from fixture").
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONString(`{"bool_false2": false, "nested_object": {"inner_string2": "space"}}`))
+	expectNoDiffs(t, diffable.DiffAgainst(expected))
+
+	// add deletions
+	diffable = diffable.Modify(`del(.remove_me)`, `del(.also_remove)`)
+	expectedWithDeletion := bytes.Replace(expected, []byte(`  "remove_me": "should be deleted",
+`), []byte(""), 1)
+	expectedWithDeletion = bytes.Replace(expectedWithDeletion, []byte(`  "also_remove": "should also be deleted",
+`), []byte(""), 1)
+	expectNoDiffs(t, diffable.DiffAgainst(expectedWithDeletion))
+
+	// check when starting from the string and adding a json to it
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableContentWithVariables deep merge from string").
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONFixture("fixtures/modification.json"))
+	expectNoDiffs(t, diffable.DiffAgainst(expected))
+
+	// add deletions
+	diffable = diffable.Modify(`del(.remove_me)`, `del(.also_remove)`)
+	expectNoDiffs(t, diffable.DiffAgainst(expectedWithDeletion))
+
+	// check multiple modifications work (they can be no-op)
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableContentWithVariables deep merge from string").
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONFixture("fixtures/modification.json")).
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONFixture("fixtures/modification.json")).
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONFixture("fixtures/modification.json"))
+	expectNoDiffs(t, diffable.DiffAgainst(expected))
+
+	// place the modification a second time within the nested object and add a normal modification
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableContentWithVariables deep merge from string").
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONFixture("fixtures/modification.json")).
+		ModifyWithVariable(".nested_object |= . * $ref", httptest.JQUnmodifiedJSONString(`{"nested_object2":{"inner_string3": "milkyway"}}`)).
+		Modify(`del(.remove_me)`, `del(.also_remove)`)
+	expected = bytes.Replace(expectedWithDeletion, []byte(`"inner_string2": "space"
+`), []byte(`"inner_string2": "space",
+    "nested_object2": {
+      "inner_string3": "milkyway"
+    }
+`), 1)
+	expectNoDiffs(t, diffable.DiffAgainst(expected))
+
+	// check that the serialization works
+	assert.Equal(t, must.ReturnT(json.Marshal(diffable))(t), bytes.ReplaceAll(bytes.ReplaceAll(expected, []byte("\n"), []byte("")), []byte(" "), []byte("")))
+
+	// non-existent file
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableContentWithVariables file not found").
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONFixture("fixtures/nonexistent.json"))
+	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
+		`JSON string processing error (failed to read data for $ref #1 for test "TestJQModifiableContentWithVariables file not found": failed to read fixture file fixtures/nonexistent.json: open fixtures/nonexistent.json: no such file or directory): expected <unknown>, but got something`,
+	)
+
+	// invalid json
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableContentWithVariables invalid json").
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONFixture("fixtures/example.txt"))
+	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
+		`JSON string processing error (failed to read data for $ref #1 for test "TestJQModifiableContentWithVariables invalid json": failed to process fixture file fixtures/example.txt: failed to parse input: invalid character 'H' looking for beginning of value): expected <unknown>, but got something`,
+	)
+
+	// invalid json string
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableContentWithVariables invalid json string").
+		ModifyWithVariable(". * $ref", httptest.JQUnmodifiedJSONString("bla"))
+	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
+		`JSON string processing error (failed to read data for $ref #1 for test "TestJQModifiableContentWithVariables invalid json string": failed to parse input: invalid character 'b' looking for beginning of value): expected <unknown>, but got something`,
+	)
+
+	// wrong number of refs
+	diffable = httptest.NewJQModifiableJSONString(testString, "TestJQModifiableContentWithVariables invalid modification").
+		ModifyWithVariable(". * $ref * $ref", httptest.JQUnmodifiedJSONFixture("fixtures/modification.json"))
+	assert.Equal(t, diffable.DiffAgainst([]byte("something"))[0].String(),
+		`JSON string processing error (different number of $ref used than provided for test "TestJQModifiableContentWithVariables invalid modification": 2 used, 1 provided): expected <unknown>, but got something`,
 	)
 }


### PR DESCRIPTION
We realized that we not only have frequent duplication between test fixtures, but also between the config JSON strings in https://github.com/sapcc/limes.
To be more flexible, you can now
* work with application-layer JSON strings instead of fixture files, so that you don't need to switch to a file for just a few lines
* `ModifyWithVariable` and use JSON fixture files as well as json strings as variable payload within the `jq` syntax, making it really easy to merge multiple fixtures and strings (also possible in a nested form).
* serialize the result of all operations via `json.Marshaler` interface to be handed to e.g. a config parser.
* the code is shared between JSON strings and fixture files in a way, where a fixture file only adds the parsing to the JSON string logic.