### PR TITLE
httpapi: introduce Composer in API.AddTo() signature

### DIFF
--- a/httpapi/api.go
+++ b/httpapi/api.go
@@ -17,7 +17,18 @@ import (
 // "Without..." are available that apply to the entire http.Handler returned by
 // Compose(), instead of just adding endpoints to it.
 type API interface {
-	AddTo(r *mux.Router)
+	AddTo(c *Composer)
+}
+
+// Composer is the argument type given to the AddTo() method of [API].
+// API implementations can use the methods on this type to register their endpoints.
+type Composer struct {
+	r *mux.Router
+}
+
+// Router returns a [mux.Router] where APIs can register endpoints.
+func (c *Composer) Router() *mux.Router {
+	return c.r
 }
 
 // HealthCheckAPI is an API with one endpoint, "GET /healthcheck", that
@@ -31,8 +42,8 @@ type HealthCheckAPI struct {
 }
 
 // AddTo implements the API interface.
-func (h HealthCheckAPI) AddTo(r *mux.Router) {
-	r.Methods("GET", "HEAD").Path("/healthcheck").HandlerFunc(h.handleRequest)
+func (h HealthCheckAPI) AddTo(c *Composer) {
+	c.Router().Methods("GET", "HEAD").Path("/healthcheck").HandlerFunc(h.handleRequest)
 }
 
 func (h HealthCheckAPI) handleRequest(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +71,7 @@ type pseudoAPI struct {
 }
 
 // AddTo implements the API interface.
-func (p pseudoAPI) AddTo(r *mux.Router) {
+func (p pseudoAPI) AddTo(c *Composer) {
 	// no-op, see above
 }
 

--- a/httpapi/compose.go
+++ b/httpapi/compose.go
@@ -16,6 +16,7 @@ func Compose(apis ...API) http.Handler {
 	autoConfigureMetricsIfNecessary()
 
 	r := mux.NewRouter()
+	c := &Composer{r}
 	m := middleware{inner: r}
 
 	// Automatically identify the endpoint for go-bits metrics using EndpointNamer,
@@ -36,7 +37,7 @@ func Compose(apis ...API) http.Handler {
 		case pseudoAPI:
 			a.configure(&m)
 		default:
-			a.AddTo(r)
+			a.AddTo(c)
 		}
 	}
 

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -161,8 +161,8 @@ func TestMetrics(t *testing.T) {
 
 type metricsTestingAPI struct{}
 
-func (m metricsTestingAPI) AddTo(r *mux.Router) {
-	r.Methods("POST").Path("/sleep/{secs}/return/{count}").HandlerFunc(m.handleRequest)
+func (m metricsTestingAPI) AddTo(c *Composer) {
+	c.Router().Methods("POST").Path("/sleep/{secs}/return/{count}").HandlerFunc(m.handleRequest)
 }
 
 func (m metricsTestingAPI) handleRequest(w http.ResponseWriter, r *http.Request) {
@@ -233,16 +233,16 @@ func TestIdentifyEndpointOverridesNamer(t *testing.T) {
 
 type endpointNamerTestAPI struct{}
 
-func (a endpointNamerTestAPI) AddTo(r *mux.Router) {
-	r.Methods("GET").Path("/test-namer").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func (a endpointNamerTestAPI) AddTo(c *Composer) {
+	c.Router().Methods("GET").Path("/test-namer").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "ok", http.StatusOK)
 	})
 }
 
 type endpointIdentifyTestAPI struct{}
 
-func (a endpointIdentifyTestAPI) AddTo(r *mux.Router) {
-	r.Methods("GET").Path("/test-identify").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func (a endpointIdentifyTestAPI) AddTo(c *Composer) {
+	c.Router().Methods("GET").Path("/test-identify").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		IdentifyEndpoint(r, "handler-explicit-endpoint")
 		http.Error(w, "ok", http.StatusOK)
 	})

--- a/httpapi/pprofapi/pprofapi.go
+++ b/httpapi/pprofapi/pprofapi.go
@@ -31,12 +31,12 @@ type API struct {
 }
 
 // AddTo implements the httpapi.API interface.
-func (a API) AddTo(r *mux.Router) {
+func (a API) AddTo(c *httpapi.Composer) {
 	if a.IsAuthorized == nil {
 		panic("API.AddTo() called with IsAuthorized == nil!")
 	}
 
-	r.Methods("GET").Path("/debug/pprof/{operation}").HandlerFunc(a.handler)
+	c.Router().Methods("GET").Path("/debug/pprof/{operation}").HandlerFunc(a.handler)
 }
 
 func (a API) handler(w http.ResponseWriter, r *http.Request) {

--- a/liquidapi/liquidapi.go
+++ b/liquidapi/liquidapi.go
@@ -274,7 +274,8 @@ var diffOptions = append(
 )
 
 // AddTo implements the httpapi.API interface.
-func (rt *runtime) AddTo(r *mux.Router) {
+func (rt *runtime) AddTo(c *httpapi.Composer) {
+	r := c.Router()
 	r.Methods("GET").Path("/v1/info").HandlerFunc(rt.handleGetInfo)
 	r.Methods("POST").Path("/v1/report-capacity").HandlerFunc(rt.handleReportCapacity)
 	r.Methods("POST").Path("/v1/projects/{project_id}/report-usage").HandlerFunc(rt.handleReportUsage)


### PR DESCRIPTION
I want to have the option of making gorilla/mux an optional dependency of httpapi, in order to remove it for the hot path in applications where its regex matching takes up a non-negligible amount of time.

The hard part of this is how to slip these non-gorilla/mux handlers into an API that is heavily based on passing a `*mux.Router` around. In https://github.com/sapcc/keppel/pull/781, I tried going with the same approach as for pseudo-APIs:

```go
type TryHandler interface {
       TryServeHTTP(http.ResponseWriter, *http.Request) bool
}

func UnmuxedAPI(h TryHandler) API {
       return pseudoAPI{tryHandler: h}
}
```

But in my opinion, the resulting API is rather ugly, and the part where, to obtain something compatible with gorilla/mux, you put something that is not into a "nuh-uh" wrapper, is going to cause confusion.

With this option exhausted, the only other option is to break backwards compatibility. This changeset does just that, replacing the `*mux.Router` argument in API.AddTo() with `*httpapi.Composer`. The Composer struct is only a thin wrapper around a `mux.Router` right now, but my intent is to add additional methods to it later that allow registering endpoints in other ways, e.g. through gg/pathrouter or by just giving a TryHandler directly, so that the `mux.Router` may stay uninstantiated if nothing requires it.